### PR TITLE
Final update for 5.06

### DIFF
--- a/PVS_Inventory_V5_ReadMe.rtf
+++ b/PVS_Inventory_V5_ReadMe.rtf
@@ -1,19 +1,19 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f39\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f39\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
-{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f279\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f280\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
-{\f282\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f283\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f284\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\f285\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
-{\f286\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f287\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f299\fbidi \fmodern\fcharset238\fprq1 Courier New CE;}{\f300\fbidi \fmodern\fcharset204\fprq1 Courier New Cyr;}
-{\f302\fbidi \fmodern\fcharset161\fprq1 Courier New Greek;}{\f303\fbidi \fmodern\fcharset162\fprq1 Courier New Tur;}{\f304\fbidi \fmodern\fcharset177\fprq1 Courier New (Hebrew);}{\f305\fbidi \fmodern\fcharset178\fprq1 Courier New (Arabic);}
-{\f306\fbidi \fmodern\fcharset186\fprq1 Courier New Baltic;}{\f307\fbidi \fmodern\fcharset163\fprq1 Courier New (Vietnamese);}{\f619\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}{\f620\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}
-{\f622\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f623\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f626\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}{\f627\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}
-{\f649\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}{\f650\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}{\f652\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}{\f653\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}
-{\f654\fbidi \fswiss\fcharset177\fprq2 Calibri (Hebrew);}{\f655\fbidi \fswiss\fcharset178\fprq2 Calibri (Arabic);}{\f656\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}{\f657\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}
-{\f669\fbidi \froman\fcharset238\fprq2 Cambria CE;}{\f670\fbidi \froman\fcharset204\fprq2 Cambria Cyr;}{\f672\fbidi \froman\fcharset161\fprq2 Cambria Greek;}{\f673\fbidi \froman\fcharset162\fprq2 Cambria Tur;}
-{\f676\fbidi \froman\fcharset186\fprq2 Cambria Baltic;}{\f677\fbidi \froman\fcharset163\fprq2 Cambria (Vietnamese);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f40\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f41\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
+{\f43\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f44\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f45\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\f46\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
+{\f47\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f48\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f60\fbidi \fmodern\fcharset238\fprq1 Courier New CE;}{\f61\fbidi \fmodern\fcharset204\fprq1 Courier New Cyr;}
+{\f63\fbidi \fmodern\fcharset161\fprq1 Courier New Greek;}{\f64\fbidi \fmodern\fcharset162\fprq1 Courier New Tur;}{\f65\fbidi \fmodern\fcharset177\fprq1 Courier New (Hebrew);}{\f66\fbidi \fmodern\fcharset178\fprq1 Courier New (Arabic);}
+{\f67\fbidi \fmodern\fcharset186\fprq1 Courier New Baltic;}{\f68\fbidi \fmodern\fcharset163\fprq1 Courier New (Vietnamese);}{\f380\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}{\f381\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}
+{\f383\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f384\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f387\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}{\f388\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}
+{\f410\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}{\f411\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}{\f413\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}{\f414\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}
+{\f415\fbidi \fswiss\fcharset177\fprq2 Calibri (Hebrew);}{\f416\fbidi \fswiss\fcharset178\fprq2 Calibri (Arabic);}{\f417\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}{\f418\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}
+{\f430\fbidi \froman\fcharset238\fprq2 Cambria CE;}{\f431\fbidi \froman\fcharset204\fprq2 Cambria Cyr;}{\f433\fbidi \froman\fcharset161\fprq2 Cambria Greek;}{\f434\fbidi \froman\fcharset162\fprq2 Cambria Tur;}
+{\f437\fbidi \froman\fcharset186\fprq2 Cambria Baltic;}{\f438\fbidi \froman\fcharset163\fprq2 Cambria (Vietnamese);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
 {\flomajor\f31509\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\flomajor\f31511\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\flomajor\f31512\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
 {\flomajor\f31513\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\flomajor\f31514\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\flomajor\f31515\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
 {\flomajor\f31516\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fdbmajor\f31518\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fdbmajor\f31519\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -117,12 +117,12 @@ Hyperlink;}}{\*\listtable{\list\listtemplateid-1612023500\listhybrid{\listlevel\
 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
 \fi-180\li6480\lin6480 }{\listname ;}\listid2008631076}}{\*\listoverridetable{\listoverride\listid558714133\listoverridecount0\ls1}{\listoverride\listid676005662\listoverridecount0\ls2}{\listoverride\listid1940482595\listoverridecount0\ls3}
 {\listoverride\listid872425844\listoverridecount0\ls4}{\listoverride\listid2008631076\listoverridecount0\ls5}{\listoverride\listid314996233\listoverridecount0\ls6}{\listoverride\listid1217358328\listoverridecount0\ls7}{\listoverride\listid642077380
-\listoverridecount0\ls8}}{\*\rsidtbl \rsid153717\rsid2246377\rsid2584501\rsid2585069\rsid3085909\rsid3345712\rsid4090611\rsid4482658\rsid7282308\rsid8982599\rsid11218240\rsid11558710\rsid12087820\rsid12282547\rsid12988199\rsid13253201\rsid13265712
-\rsid14316788\rsid14772334\rsid14894181}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator webster}{\creatim\yr2014\mo4\dy1\hr13\min41}
-{\revtim\yr2016\mo9\dy12\hr11}{\version14}{\edmins104}{\nofpages13}{\nofwords3867}{\nofchars22045}{\nofcharsws25861}{\vern57441}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
+\listoverridecount0\ls8}}{\*\rsidtbl \rsid153717\rsid2246377\rsid2584501\rsid2585069\rsid3085909\rsid3345712\rsid4090611\rsid4482658\rsid5405950\rsid7282308\rsid8982599\rsid11218240\rsid11558710\rsid12087820\rsid12282547\rsid12988199\rsid13253201
+\rsid13265712\rsid14316788\rsid14772334\rsid14894181}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator webster}{\creatim\yr2014\mo4\dy1\hr13\min41}
+{\revtim\yr2016\mo9\dy14\hr12\min21}{\version15}{\edmins105}{\nofpages13}{\nofwords3867}{\nofchars22045}{\nofcharsws25861}{\vern57441}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
 \paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot14894181 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot14894181 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -235,33 +235,33 @@ PVS_Inventory_V5.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
 \par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \\\hich\af2\dbch\af31505\loch\f2 
-PVS_Inventory_V5.ps1 [-MSWord] [-Hardware] [-StartDate <DateTime>] [-EndDate <DateTime>\hich\af2\dbch\af31505\loch\f2 
-] [-AddDateTime] [-AdminAddress <String>] [-Domain <String>] [-User <String>] [-Password <String>] [-Folder <String>] [-CompanyName <String>] [-CoverPage <String>] [-UserName <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
+PVS_Inventory_V5.ps1 [-MSWord] [-Hardware] [-StartDate <DateTime>] [-EndDate <DateTime>] [-AddDateTime] [-AdminAddress <String>] [-Domain <String>] [-User <String>] [-Password <String>] [-Folder <String>] [-CompanyName <String>] [-CoverPage <String>] [-Us
+\hich\af2\dbch\af31505\loch\f2 e\hich\af2\dbch\af31505\loch\f2 rName <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \\\hich\af2\dbch\af31505\loch\f2 
-PVS_Inv\hich\af2\dbch\af31505\loch\f2 
-entory_V5.ps1 [-MSWord] [-PDF] [-Text] [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <DateTime>] [-AddDateTime] [-AdminAddress <String>] [-Domain <String>] [-User <String>] [-Password <String>] [-Folder <String>] [-CompanyName <String>] [-CoverPag
-\hich\af2\dbch\af31505\loch\f2 e\hich\af2\dbch\af31505\loch\f2  <String>] [-UserName <String>] -SmtpServer <String> [-SmtpPort <Int32>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 [-UseSSL] -From <String> -To <String> [-Dev] [-ScriptInfo] [<CommonParameters>]
+PVS_Inventory_V5.ps1 [-MSWord] [-PDF] [-Text] [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <DateTime>] [-AddDateTime] [-AdminAddress <String>] [-Domain <String>] [-User <Str\hich\af2\dbch\af31505\loch\f2 
+ing>] [-Password <String>] [-Folder <String>] [-CompanyName <String>] [-CoverPage <String>] [-UserName <String>] -SmtpServer <String> [-SmtpPort <Int32>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 [-UseSSL] -From <String> -To <String> [-Dev] [-ScriptInfo] [<CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \\\hich\af2\dbch\af31505\loch\f2 
-PVS_Inventory_V5.ps1 [-PDF] [-Hardware] [-StartDate <DateTime>] [-EndDate <DateTime>] [-AddDateTime] [-AdminAddress <String>] [-Domain <String>] [-User <String>] [-Password <String>] [-Folder <String>] [-CompanyName <String>] [-CoverPa
-\hich\af2\dbch\af31505\loch\f2 ge <String>] [-UserName <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
+PVS_In\hich\af2\dbch\af31505\loch\f2 
+ventory_V5.ps1 [-PDF] [-Hardware] [-StartDate <DateTime>] [-EndDate <DateTime>] [-AddDateTime] [-AdminAddress <String>] [-Domain <String>] [-User <String>] [-Password <String>] [-Folder <String>] [-CompanyName <String>] [-CoverPage <String>] [-UserName <S
+\hich\af2\dbch\af31505\loch\f2 t\hich\af2\dbch\af31505\loch\f2 ring>] [-Dev] [-ScriptInfo] [<CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \\\hich\af2\dbch\af31505\loch\f2 
-PVS_Inventory_V5.ps1 [-Text] [-Hardware] [-StartDate <DateTime>] [-EndDate <DateTime>] [-AddDateTime] [-AdminAddress <String>] [-Domain <String>] [-User <Stri\hich\af2\dbch\af31505\loch\f2 
-ng>] [-Password <String>] [-Folder <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
+PVS_Inventory_V5.ps1 [-Text] [-Hardware] [-StartDate <DateTime>] [-EndDate <DateTime>] [-AddDateTime] [-AdminAddress <String>] [-Domain <String>] [-User <String>] [-Password <String>] [-Folde\hich\af2\dbch\af31505\loch\f2 
+r <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \\\hich\af2\dbch\af31505\loch\f2 
-PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <DateTime>] [-AddDateTime] [-AdminAddress <String>] [-Domain <String>] [\hich\af2\dbch\af31505\loch\f2 
--User <String>] [-Password <String>] [-Folder <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
+PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <DateTime>] [-AddDateTime] [-AdminAddress <String>] [-Domain <String>] [-User <String>] [-Password <String>] [-\hich\af2\dbch\af31505\loch\f2 
+Folder <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
 \par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of a Citrix PVS 7.x Farm using Microsoft PowerShell, Word,
 \par \hich\af2\dbch\af31505\loch\f2     plain text or HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the s\hich\af2\dbch\af31505\loch\f2 cript. This script will output in Text and HTML.
+\par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the script. This script will output in Text \hich\af2\dbch\af31505\loch\f2 and HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a PVS Server. This script was developed and run
 \par \hich\af2\dbch\af31505\loch\f2     from a Windows 8.1 VM.
@@ -277,7 +277,7 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2         For 64-bit:
 \par \hich\af2\dbch\af31505\loch\f2                 %systemroot%\\Microsoft.NET\\Framework64\\v4.0.30319\\installutil.exe "%ProgramFiles%\\Citrix\\Provisioning Services Console\\Citrix.PVS.SnapIn.dll"
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after the PVS farm.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Creates an output file named after the PVS farm.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word and PDF Document includes a Cover Page, Table of Contents and Footer.
 \par 
@@ -285,7 +285,7 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Danish
 \par \hich\af2\dbch\af31505\loch\f2         Dutch
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        English
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     English
 \par \hich\af2\dbch\af31505\loch\f2         Finnish
 \par \hich\af2\dbch\af31505\loch\f2         French
 \par \hich\af2\dbch\af31505\loch\f2         German
@@ -306,26 +306,26 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchPara\hich\af2\dbch\af31505\loch\f2 meter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        This parameter uses the Word SaveAs PDF capability.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter\hich\af2\dbch\af31505\loch\f2  uses the Word SaveAs PDF capability.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard \hich\af2\dbch\af31505\loch\f2 characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    -Text [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Def\hich\af2\dbch\af31505\loch\f2 ault value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default\hich\af2\dbch\af31505\loch\f2  value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -333,19 +333,19 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         R\hich\af2\dbch\af31505\loch\f2 equired?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on: Computer System, Disks, Processor and Network Interface Cards
+\par \hich\af2\dbch\af31505\loch\f2         Use WMI\hich\af2\dbch\af31505\loch\f2  to gather hardware information on: Computer System, Disks, Processor and Network Interface Cards
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of HW.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         P\hich\af2\dbch\af31505\loch\f2 osition?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?       \hich\af2\dbch\af31505\loch\f2              named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -367,7 +367,7 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -EndDate <DateTime>
+\par \hich\af2\dbch\af31505\loch\f2     -En\hich\af2\dbch\af31505\loch\f2 dDate <DateTime>
 \par \hich\af2\dbch\af31505\loch\f2         End date for the Audit Trail report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Format for date only is MM/DD/YYYY.
@@ -375,37 +375,37 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2         Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24 hour format.
 \par \hich\af2\dbch\af31505\loch\f2         The double quotes are needed.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         De\hich\af2\dbch\af31505\loch\f2 fault is today's date.
+\par \hich\af2\dbch\af31505\loch\f2         Default i\hich\af2\dbch\af31505\loch\f2 s today's date.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ED.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                (Get-Date -displayhint date)
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       \hich\af2\dbch\af31505\loch\f2 false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2         Time stamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2         June 1, 2015 at 6PM is 2015-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Output filename will be ReportName_2015-06-01_1800.docx (or .pdf).
+\par \hich\af2\dbch\af31505\loch\f2         Out\hich\af2\dbch\af31505\loch\f2 put filename will be ReportName_2015-06-01_1800.docx (or .pdf).
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ADT.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Defaul\hich\af2\dbch\af31505\loch\f2 t value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AdminAddress <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the name of a PVS server that the PowerShell script will connect to.
-\par \hich\af2\dbch\af31505\loch\f2         Usin\hich\af2\dbch\af31505\loch\f2 g this parameter requires the script be run from an elevated PowerShell session.
+\par \hich\af2\dbch\af31505\loch\f2         Using this paramet\hich\af2\dbch\af31505\loch\f2 er requires the script be run from an elevated PowerShell session.
 \par \hich\af2\dbch\af31505\loch\f2         Starting with V5.04 of the script, this requirement is now checked.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of AA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Posi\hich\af2\dbch\af31505\loch\f2 tion?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?         \hich\af2\dbch\af31505\loch\f2            named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -422,14 +422,14 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2     -User <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the user used for the AdminAddress connection.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Password <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the password used fo\hich\af2\dbch\af31505\loch\f2 r the AdminAddress connection.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the password used for t\hich\af2\dbch\af31505\loch\f2 he AdminAddress connection.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -454,15 +454,15 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
 \par \hich\af2\dbch\af31505\loch\f2         If either registry key does not exist and this parameter is not specified, the report will}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 not contain a Company Name on the cover page.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This paramete\hich\af2\dbch\af31505\loch\f2 r is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard \hich\af2\dbch\af31505\loch\f2 characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    -CoverPage <String>
 \par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
 \par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
 \par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
@@ -472,35 +472,35 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly works in 2010 but}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 Subtitle/Subject & Author fields need to be moved}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 after title box is moved up)
+\ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 Subtitle/Subject & Author fields need to be\hich\af2\dbch\af31505\loch\f2  moved}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 after title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Wo\hich\af2\dbch\af31505\loch\f2 rd 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. \hich\af2\dbch\af31505\loch\f2 Works if you like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be manually resized or font}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Io\hich\af2\dbch\af31505\loch\f2 n (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be manually resized or font}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be manually resized or font}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                \hich\af2\dbch\af31505\loch\f2  Motion (Word 2010/2013/2016. Works if top date is manually changed to 36 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Mod\hich\af2\dbch\af31505\loch\f2  (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to 36 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
 \par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2            \hich\af2\dbch\af31505\loch\f2      Puzzle (Word 2010. Top date doesn't fit; box needs to be manually resized or font}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 changed to 14 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Pinstr\hich\af2\dbch\af31505\loch\f2 ipes (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually resized or font}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 changed to 14 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2          Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in 2010)
+\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2         Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
+\par \hich\af2\dbch\af31505\loch\f2              \hich\af2\dbch\af31505\loch\f2    Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
@@ -512,19 +512,19 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
 \par \hich\af2\dbch\af31505\loch\f2         User name to use for the Cover Page and Footer.
 \par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $env:username
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of\hich\af2\dbch\af31505\loch\f2  UN.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?   \hich\af2\dbch\af31505\loch\f2     false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       fal\hich\af2\dbch\af31505\loch\f2 se
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
@@ -532,7 +532,7 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default valu\hich\af2\dbch\af31505\loch\f2 e
+\par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -542,7 +542,7 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                25
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Default value                25
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -550,14 +550,14 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
 \par \hich\af2\dbch\af31505\loch\f2         Default is False.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Requi\hich\af2\dbch\af31505\loch\f2 red?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?\hich\af2\dbch\af31505\loch\f2                     false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -From <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for\hich\af2\dbch\af31505\loch\f2  the From email address.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the\hich\af2\dbch\af31505\loch\f2  From email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
@@ -572,21 +572,21 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         De\hich\af2\dbch\af31505\loch\f2 fault value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
-\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the scri\hich\af2\dbch\af31505\loch\f2 pt.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    This is used when the script developer requests more troubleshooting data.
 \par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         P\hich\af2\dbch\af31505\loch\f2 osition?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -599,19 +599,19 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?            \hich\af2\dbch\af31505\loch\f2         named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
-\par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose,\hich\af2\dbch\af31505\loch\f2  Debug,
-\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+\par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
+\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, \hich\af2\dbch\af31505\loch\f2 ErrorVariable, WarningAction, WarningVariable,
 \par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
 \par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
-\par \hich\af2\dbch\af31505\loch\f2     None.  Y\hich\af2\dbch\af31505\loch\f2 ou cannot pipe objects to this script.
+\par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to thi\hich\af2\dbch\af31505\loch\f2 s script.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
@@ -620,32 +620,32 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: PVS_Inventory_V5.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 5.05
-\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster, Sr. Solutions Archite\hich\af2\dbch\af31505\loch\f2 ct at Choice Solutions
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: September 12, 2016
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5405950 \hich\af2\dbch\af31505\loch\f2         VERSION: 5.06}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 
+\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster, Sr. Solutions Architect at Choice Solutions
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5405950 \hich\af2\dbch\af31505\loch\f2         LASTEDIT: September 14}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 , 2016
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company=\hich\af2\dbch\af31505\loch\f2 "Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par \hich\af2\dbch\af31505\loch\f2     AdminAddress = LocalHost
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the \hich\af2\dbch\af31505\loch\f2 User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -----------------------\hich\af2\dbch\af31505\loch\f2 --- EXAMPLE 2 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1 -PDF
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\\hich\af2\dbch\af31505\loch\f2 Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:\hich\af2\dbch\af31505\loch\f2 username = Administrator
 \par \hich\af2\dbch\af31505\loch\f2     AdminAddress = LocalHost
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -659,13 +659,13 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1 -TEXT
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a formatted text file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\\hich\af2\dbch\af31505\loch\f2 Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\Us\hich\af2\dbch\af31505\loch\f2 erInfo\\CompanyName="Carl Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the C\hich\af2\dbch\af31505\loch\f2 over Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator \hich\af2\dbch\af31505\loch\f2 for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
 \par 
 \par 
@@ -673,8 +673,8 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1 -HTML
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the d\hich\af2\dbch\af31505\loch\f2 ocument as an HTML file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as an HTML file.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURR\hich\af2\dbch\af31505\loch\f2 ENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
@@ -686,11 +686,11 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory\hich\af2\dbch\af31505\loch\f2 _V5.ps1 -Hardware
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1 -Hardware
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and add additional information for each server about its hardware.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Defau\hich\af2\dbch\af31505\loch\f2 lt values and add additional information for each server about its hardware.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Off\hich\af2\dbch\af31505\loch\f2 ice\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster\hich\af2\dbch\af31505\loch\f2 "
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -700,7 +700,7 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V5.ps1 -CompanyName "Carl Webster Consulting" -CoverPage "Mod" -UserName "Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_\hich\af2\dbch\af31505\loch\f2 Inventory_V5.ps1 -CompanyName "Carl Webster Consulting" -CoverPage "Mod" -UserName "Carl Webster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
@@ -713,7 +713,7 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V5.ps1 -CN "Carl Webster Consulting" -CP "Mod" -UN "Carl Webster" -AdminAddress PVS1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Carl Webster Consulting for the Company Name (alias CN).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Compa\hich\af2\dbch\af31505\loch\f2 ny Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
 \par \hich\af2\dbch\af31505\loch\f2         PVS1 for AdminAddress.
@@ -721,11 +721,11 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V5.ps1 -CN "Carl Webster Consulting" -CP "Mod" -UN "Carl Webster" -AdminAddress PVS1 -User cwebster -Domain WebstersLab -Password Abc123!@#
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_I\hich\af2\dbch\af31505\loch\f2 nventory_V5.ps1 -CN "Carl Webster Consulting" -CP "Mod" -UN "Carl Webster" -AdminAddress PVS1 -User cwebster -Domain WebstersLab -Password Abc123!@#
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Compan\hich\af2\dbch\af31505\loch\f2 y Name (alias CN).
-\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
+\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover P\hich\af2\dbch\af31505\loch\f2 age format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
 \par \hich\af2\dbch\af31505\loch\f2         PVS1 for AdminAddress.
 \par \hich\af2\dbch\af31505\loch\f2         cwebster for User.
@@ -746,9 +746,25 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2         Script will prompt for the Domain and Password
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  -------------------------- EXAMPLE 10 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -\hich\af2\dbch\af31505\loch\f2 ------------------------- EXAMPLE 10 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1 -StartDate "01/01/2015" -EndDate "01/31/2015"
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Comp\hich\af2\dbch\af31505\loch\f2 any="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     AdminAddress = LocalHost
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     Will return all Audit\hich\af2\dbch\af31505\loch\f2  Trail entries from "01/01/2015" through "01/31/2015".
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 11 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1 -StartDate "01/01/2015 10:00:00" -EndDate "01/31/2015 14:00:00"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
@@ -756,23 +772,7 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2     AdminAddress = LocalHost
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the \hich\af2\dbch\af31505\loch\f2 User Name.
-\par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
-\par \hich\af2\dbch\af31505\loch\f2     Will return all Audit Trail entries from "01/01/2015" through "01/31/2015".
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 11 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1 -StartDate "01/0\hich\af2\dbch\af31505\loch\f2 1/2015 10:00:00" -EndDate "01/31/2015 14:00:00"
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
-\par \hich\af2\dbch\af31505\loch\f2     AdminAddress = LocalHost
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for th\hich\af2\dbch\af31505\loch\f2 e Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page f\hich\af2\dbch\af31505\loch\f2 ormat.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
 \par \hich\af2\dbch\af31505\loch\f2     Will return all Audit Trail entries from 01/01/2015 10:100AM through 01/31/2015 2:00PM.
@@ -780,31 +780,31 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1 -Folder \\\\FileServer\\ShareName
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScri\hich\af2\dbch\af31505\loch\f2 pt >.\\PVS_Inventory_V5.ps1 -Folder \\\\FileServer\\ShareName
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="C\hich\af2\dbch\af31505\loch\f2 arl Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Compan\hich\af2\dbch\af31505\loch\f2 y="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Output file will be saved in the path \\\\FileServer\\ShareName
+\par \hich\af2\dbch\af31505\loch\f2     Output file will be saved in the path \\\\FileServer\\ShareName
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1 -SmtpServer mail.domain.tld -From XDAdmin@domain.tld -To ITGroup@domain.tld\hich\af2\dbch\af31505\loch\f2  -ComputerName DHCPServer01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1 -SmtpServer mail.domain.tld -From XDAdmin@domain.tld -To ITGroup@domain.tld -ComputerName DHCPServer01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HK\hich\af2\dbch\af31505\loch\f2 EY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:user\hich\af2\dbch\af31505\loch\f2 name = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sid\hich\af2\dbch\af31505\loch\f2 eline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer01.
@@ -813,23 +813,23 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted to enter valid credentials.
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ---------\hich\af2\dbch\af31505\loch\f2 ----------------- EXAMPLE 14 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1 -SmtpServer smtp.office365.com -SmtpPort 587 -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1 -SmtpServer smtp.off\hich\af2\dbch\af31505\loch\f2 ice365.com -SmtpPort 587 -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CU\hich\af2\dbch\af31505\loch\f2 RRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micros\hich\af2\dbch\af31505\loch\f2 oft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline\hich\af2\dbch\af31505\loch\f2  for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer01.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server smtp.office365.com on port 587 using SSL, sending from webster@carlwebster.com, sendin\hich\af2\dbch\af31505\loch\f2 g to ITGroup@carlwebster.com.
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted to enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server smtp.office365.com on port 587 using SSL, sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credential\hich\af2\dbch\af31505\loch\f2 s are not valid to send email, the user will be prompted to enter valid credentials.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 
@@ -951,8 +951,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000e029
-91ca0e0dd201feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000002044
+b269ac0ed201feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/PVS_Script_ChangeLog.txt
+++ b/PVS_Script_ChangeLog.txt
@@ -6,6 +6,44 @@
 #Thanks to Michael B. Smith, Joe Shonk and Stephane Thirion
 #for testing and fine-tuning tips 
 
+#Version 5.06 14-Sep-2016
+#	Add support for PVS 7.11
+#	Change version checking to support a four character version number
+#	Add to Farm properties, Customer Experience Improvement Program
+#	Add to Farm properties, CIS Username
+#	Add to Site properties, Seconds between vDisk inventory scans
+#	Add to Server properties, Problem Report Date, Summary and Status
+#	Add, Fix, Remove or Update Audit Trail items:
+#		2009 Run WithReturnBoot
+#		2021 Run WithReturnDisplayMessage
+#		2033 Run WithReturnReboot
+#		2042 Run WithReturnShutdown
+#		2055 Run ExportDisk
+#		2056 Run AssignDisk
+#		2057 Run RemoveDisk
+#		2058 Run DiskUpdateStart
+#		2059 Run DiskUpdateCancel
+#		2060 Run SetOverrideVersion
+#		2061 Run CancelTask
+#		2062 Run ClearTask
+#		2063 Run ForceInventory
+#		2064 Run UpdateBDM
+#		2065 Run StartDeviceDiskTempVersionMode
+#		2066 Run StopDeviceDiskTempVersionMode
+#		Remove previous obsolete audit values 7013 through 7033
+#		Add the following new audit values 7013 through 7021
+#		7013 Set ListDiskLocatorCustomProperty
+#		7014 Set ListDiskLocatorCustomPropertyDelete
+#		7015 Set ListDiskLocatorCustomPropertyAdd
+#		7016 Set ListServerCustomProperty
+#		7017 Set ListServerCustomPropertyDelete
+#		7018 Set ListServerCustomPropertyAdd
+#		7019 Set ListUserGroupCustomProperty
+#		7020 Set ListUserGroupCustomPropertyDelete
+#		7021 Set ListUserGroupCustomPropertyAdd	
+#	Add write-cache type 6, Device RAM Disk, only because it is in the cmdlet's help text
+#	Fix issues with invalid variable names found by using the -Dev parameter
+
 #Version 5.05 12-Sep-2016
 #	Add ShowScriptOptions when using TEXT or HTML
 #	Add in support for the -Dev and -ScriptInfo parameters


### PR DESCRIPTION
#Version 5.06 14-Sep-2016
#	Add support for PVS 7.11
#	Change version checking to support a four character version number
#	Add to Farm properties, Customer Experience Improvement Program
#	Add to Farm properties, CIS Username
#	Add to Site properties, Seconds between vDisk inventory scans
#	Add to Server properties, Problem Report Date, Summary and Status
#	Add, Fix, Remove or Update Audit Trail items:
#		2009 Run WithReturnBoot
#		2021 Run WithReturnDisplayMessage
#		2033 Run WithReturnReboot
#		2042 Run WithReturnShutdown
#		2055 Run ExportDisk
#		2056 Run AssignDisk
#		2057 Run RemoveDisk
#		2058 Run DiskUpdateStart
#		2059 Run DiskUpdateCancel
#		2060 Run SetOverrideVersion
#		2061 Run CancelTask
#		2062 Run ClearTask
#		2063 Run ForceInventory
#		2064 Run UpdateBDM
#		2065 Run StartDeviceDiskTempVersionMode
#		2066 Run StopDeviceDiskTempVersionMode
#		Remove previous obsolete audit values 7013 through 7033
#		Add the following new audit values 7013 through 7021
#		7013 Set ListDiskLocatorCustomProperty
#		7014 Set ListDiskLocatorCustomPropertyDelete
#		7015 Set ListDiskLocatorCustomPropertyAdd
#		7016 Set ListServerCustomProperty
#		7017 Set ListServerCustomPropertyDelete
#		7018 Set ListServerCustomPropertyAdd
#		7019 Set ListUserGroupCustomProperty
#		7020 Set ListUserGroupCustomPropertyDelete
#		7021 Set ListUserGroupCustomPropertyAdd	
#	Add write-cache type 6, Device RAM Disk, only because it is in the cmdlet's help text
#	Fix issues with invalid variable names found by using the -Dev parameter