### PR TITLE
Final update for 5.12

### DIFF
--- a/PVS_Inventory_V5_ReadMe.rtf
+++ b/PVS_Inventory_V5_ReadMe.rtf
@@ -115,12 +115,12 @@ Hyperlink;}}{\*\listtable{\list\listtemplateid-1612023500\listhybrid{\listlevel\
 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
 \fi-180\li6480\lin6480 }{\listname ;}\listid2008631076}}{\*\listoverridetable{\listoverride\listid558714133\listoverridecount0\ls1}{\listoverride\listid676005662\listoverridecount0\ls2}{\listoverride\listid1940482595\listoverridecount0\ls3}
 {\listoverride\listid872425844\listoverridecount0\ls4}{\listoverride\listid2008631076\listoverridecount0\ls5}{\listoverride\listid314996233\listoverridecount0\ls6}{\listoverride\listid1217358328\listoverridecount0\ls7}{\listoverride\listid642077380
-\listoverridecount0\ls8}}{\*\rsidtbl \rsid153717\rsid2246377\rsid2584501\rsid2585069\rsid3085909\rsid3154381\rsid3345712\rsid3679694\rsid4090611\rsid4482658\rsid5318453\rsid5405950\rsid7282308\rsid8982599\rsid9466969\rsid11218240\rsid11558710\rsid12087820
-\rsid12282547\rsid12988199\rsid13253201\rsid13265712\rsid14316788\rsid14772334\rsid14894181\rsid16003468}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info
-{\operator Webster}{\creatim\yr2014\mo4\dy1\hr13\min41}{\revtim\yr2016\mo12\dy16\hr14\min50}{\version19}{\edmins111}{\nofpages13}{\nofwords3921}{\nofchars22352}{\nofcharsws26221}{\vern11}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003
-/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\listoverridecount0\ls8}}{\*\rsidtbl \rsid153717\rsid735408\rsid2246377\rsid2584501\rsid2585069\rsid3085909\rsid3154381\rsid3345712\rsid3679694\rsid4090611\rsid4482658\rsid5318453\rsid5405950\rsid7282308\rsid8982599\rsid9466969\rsid10386082\rsid11218240
+\rsid11558710\rsid12087820\rsid12282547\rsid12988199\rsid13253201\rsid13265712\rsid14316788\rsid14772334\rsid14894181\rsid16003468}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0
+\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo4\dy1\hr13\min41}{\revtim\yr2017\mo2\dy17\hr8\min22}{\version21}{\edmins113}{\nofpages13}{\nofwords3921}{\nofchars22352}{\nofcharsws26221}{\vern19}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/o
+ffice/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot14894181 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot14894181 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -170,15 +170,15 @@ For Windows 8.x, Server 2012 and Server 2012 R2}{\rtlch\fcs1 \af0\afs22 \ltrch\f
 \s17\ql \fi-360\li1440\ri0\nowidctlpar\wrapdefault\faauto\ls8\ilvl1\rin0\lin1440\itap0\pararsid3085909 {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 For 32-bit}{\rtlch\fcs1 
 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2584501 \hich\af31506\dbch\af31505\loch\f31506 :}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid2584501\charrsid2584501 
 \par }\pard \ltrpar\s17\ql \li1440\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin1440\itap0\pararsid2584501 {\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid2585069\charrsid2584501 \hich\af31506\dbch\af31505\loch\f31506 %systemroot%\\Microsoft.NET\\
-Framework\\v4.0.30319\\installutil.exe }{\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \b\f39\fs22\insrsid3085909\charrsid2584501 \loch\af39\dbch\af31505\hich\f39 \'93\loch\f39 %ProgramFiles%\\Citrix\\Provisioning Services Console}{\rtlch\fcs1 \af0\afs22 
-\ltrch\fcs0 \b\f39\fs22\insrsid3085909\charrsid2584501 \\}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f39\fs22\insrsid13265712\charrsid13265712 \hich\af39\dbch\af31505\loch\f39 Citrix.PVS.SnapIn}{\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 
-\b\f39\fs22\insrsid3085909\charrsid2584501 \hich\af39\dbch\af31505\loch\f39 \hich\f39 .dll\'94}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid2585069\charrsid2584501 
+Framework\\v4.0.30319\\installutil.exe }{\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid735408 \hich\af31506\dbch\af31505\loch\f31506 "}{\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \b\f39\fs22\insrsid3085909\charrsid2584501 
+\hich\af39\dbch\af31505\loch\f39 %ProgramFiles%\\Citrix\\Provisioning Services Console}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f39\fs22\insrsid3085909\charrsid2584501 \\}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f39\fs22\insrsid13265712\charrsid13265712 
+\hich\af39\dbch\af31505\loch\f39 Citrix.PVS.SnapIn}{\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \b\f39\fs22\insrsid735408 \hich\af39\dbch\af31505\loch\f39 .dll"}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid2585069\charrsid2584501 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0 \ltrch\fcs0 \f2\insrsid2585069\charrsid2584501 \hich\af2\dbch\af31505\loch\f2 o\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\nowidctlpar\wrapdefault\faauto\ls8\ilvl1\rin0\lin1440\itap0\pararsid2584501 {
 \rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid2585069\charrsid2584501 \hich\af40\dbch\af31505\loch\f40 For 64-bit}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid2584501\charrsid2584501 \hich\af40\dbch\af31505\loch\f40 :
 \par }\pard \ltrpar\s17\ql \li1440\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin1440\itap0\pararsid2584501 {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid2585069\charrsid2584501 \hich\af31506\dbch\af31505\loch\f31506 %systemroot%\\Microsoft.NET\\
-\hich\af31506\dbch\af31505\loch\f31506 Framework64\\v4.0.30319\\installutil.exe }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid3085909\charrsid2584501 \loch\af31506\dbch\af31505\hich\f31506 \'93\loch\f31506 %ProgramFiles%\\Citrix\\
-Provisioning Services Console\\}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f39\fs22\insrsid13265712\charrsid13265712 \hich\af39\dbch\af31505\loch\f39 Citrix.PVS.SnapIn}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid3085909\charrsid2584501 
-\hich\af31506\dbch\af31505\loch\f31506 \hich\f31506 .dll\'94}{\rtlch\fcs1 \ab\af39\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid3085909\charrsid2584501 
+\hich\af31506\dbch\af31505\loch\f31506 Framework64\\v4.0.30319\\installutil.exe }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid735408 \hich\af31506\dbch\af31505\loch\f31506 "}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 
+\b\f31506\fs22\insrsid3085909\charrsid2584501 \hich\af31506\dbch\af31505\loch\f31506 %ProgramFiles%\\Citrix\\Provisioning Services Console\\}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f39\fs22\insrsid13265712\charrsid13265712 \hich\af39\dbch\af31505\loch\f39 
+Citrix.PVS.SnapIn}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid735408 \hich\af31506\dbch\af31505\loch\f31506 .dll"}{\rtlch\fcs1 \ab\af39\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid3085909\charrsid2584501 
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
 \ab\af39\afs22 \ltrch\fcs0 \b\f39\fs22\insrsid2584501 \hich\af39\dbch\af31505\loch\f39 Note:}{\rtlch\fcs1 \ab\af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid2584501 \hich\af39\dbch\af31505\loch\f39 \hich\f39 
  All lines are one line. If you copy and paste into a command prompt, watch for the smart quotes. If you get an \'93\loch\f39 \hich\f39 invalid URL\'94\loch\f39  error, pas\hich\af39\dbch\af31505\loch\f39 
@@ -188,7 +188,7 @@ If you are running 64-bit Windows Server, you will need to run both commands so 
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af40\afs26 \ltrch\fcs0 \b\fs26\cf19\insrsid2585069 \hich\af40\dbch\af31505\loch\f40 Script Usage
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
-\af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid2585069 \hich\af39\dbch\af31505\loch\f39 How to use this script?
+\af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid2585069 \hich\af39\dbch\af31505\loch\f39 How to use th\hich\af39\dbch\af31505\loch\f39 is script?
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 1.\tab}}\pard \ltrpar
 \ql \fi-720\li1080\ri0\nowidctlpar\wrapdefault\faauto\ls7\rin0\lin1080\itap0\pararsid14894181 {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 Save the script as }{\rtlch\fcs1 
 \ai\af0\afs22 \ltrch\fcs0 \i\f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 PVS_Inventory_V}{\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \i\f31506\fs22\insrsid14772334 \hich\af31506\dbch\af31505\loch\f31506 5}{\rtlch\fcs1 
@@ -203,8 +203,8 @@ From the PowerShell prompt, change to your PowerShell scripts.
 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506  and press }{\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \i\f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 Enter}{
 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 .}{\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \i\f31506\fs22\insrsid2585069\charrsid13253201 
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 4.\tab}}\pard \ltrpar
-\ql \fi-720\li1080\ri0\nowidctlpar\wrapdefault\faauto\ls7\rin0\lin1080\itap0\pararsid14894181 {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 
-By default, a Microsoft Word document is created named after the PVS Farm.
+\ql \fi-720\li1080\ri0\nowidctlpar\wrapdefault\faauto\ls7\rin0\lin1080\itap0\pararsid14894181 {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 By default, a
+\hich\af31506\dbch\af31505\loch\f31506  Microsoft Word document is created named after the PVS Farm.
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 5.\tab}\hich\af31506\dbch\af31505\loch\f31506 If you use the \hich\f31506 \endash \loch\f31506 
 PDF option, a PDF file is created named after the PVS Farm.}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid14894181\charrsid13253201 
 \par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid12282547 
@@ -275,8 +275,8 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2     For Windows 8.x, Server 2012 and Server 2012 R2, run:
 \par \hich\af2\dbch\af31505\loch\f2         For 32-bit:
 \par \hich\af2\dbch\af31505\loch\f2                 %systemroot%\\Microsoft.NET\\Framework\\v4.0.30319\\installutil.exe }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3154381 
-\par \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 "%ProgramFiles%\\Citrix\\Provisioning\hich\af2\dbch\af31505\loch\f2  Services }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3154381 
+\par \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid735408 \hich\af2\dbch\af31505\loch\f2 "}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 
+%ProgramFiles%\\Citrix\\Provisioning\hich\af2\dbch\af31505\loch\f2  Services }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3154381 
 \par \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 Console\\Citrix.PVS.SnapIn.dll"
 \par \hich\af2\dbch\af31505\loch\f2         For 64-bit:
 \par \hich\af2\dbch\af31505\loch\f2                 %systemroot%\\Microsoft.NET\\Framework64\\v4.0.30319\\installutil.exe }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3154381 
@@ -291,7 +291,7 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3154381 \tab \hich\af2\dbch\af31505\loch\f2  Chinese}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3154381\charrsid11558710 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2         Danish
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Danish
 \par \hich\af2\dbch\af31505\loch\f2         Dutch
 \par \hich\af2\dbch\af31505\loch\f2         English
 \par \hich\af2\dbch\af31505\loch\f2         Finnish
@@ -504,33 +504,33 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 resized or font}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to 36 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3679694 
+\par \hich\af2\dbch\af31505\loch\f2               \hich\af2\dbch\af31505\loch\f2   Motion (Word 2010/2013/2016. Works if top date is manually changed to 36 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3679694 
 \par \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
 \par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Pinstripe\hich\af2\dbch\af31505\loch\f2 s (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. \hich\af2\dbch\af31505\loch\f2 Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually resized }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3679694 
 \par \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 or font}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 changed to 14 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works\hich\af2\dbch\af31505\loch\f2 )
-\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
+\par \hich\af2\dbch\af31505\loch\f2              \hich\af2\dbch\af31505\loch\f2    Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Default value is Sideline.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
+\par \hich\af2\dbch\af31505\loch\f2         This\hich\af2\dbch\af31505\loch\f2  parameter has an alias of CP.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                Sidelin\hich\af2\dbch\af31505\loch\f2 e
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
+\par \hich\af2\dbch\af31505\loch\f2         Acce\hich\af2\dbch\af31505\loch\f2 pt pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
@@ -541,17 +541,17 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                $env:user\hich\af2\dbch\af31505\loch\f2 name
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       f\hich\af2\dbch\af31505\loch\f2 alse
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
-\par \hich\af2\dbch\af31505\loch\f2         Position?        \hich\af2\dbch\af31505\loch\f2             named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
@@ -559,7 +559,7 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2         Default is 25.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                25
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -568,21 +568,21 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
 \par \hich\af2\dbch\af31505\loch\f2         Default is False.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Requi\hich\af2\dbch\af31505\loch\f2 red?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -From <St\hich\af2\dbch\af31505\loch\f2 ring>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
+\par \hich\af2\dbch\af31505\loch\f2     -From <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for\hich\af2\dbch\af31505\loch\f2  the From email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipelin\hich\af2\dbch\af31505\loch\f2 e input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wild\hich\af2\dbch\af31505\loch\f2 card characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
@@ -596,7 +596,7 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
-\par \hich\af2\dbch\af31505\loch\f2         Outputs all e\hich\af2\dbch\af31505\loch\f2 rrors to a text file at the end of the script.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the scri\hich\af2\dbch\af31505\loch\f2 pt.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
 \par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
@@ -610,14 +610,14 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Outputs information about the script to a text file.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script t\hich\af2\dbch\af31505\loch\f2 o a text file.
 \par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?            \hich\af2\dbch\af31505\loch\f2         false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?            \hich\af2\dbch\af31505\loch\f2         named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -626,10 +626,10 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
 \par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
 \par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (http://g\hich\af2\dbch\af31505\loch\f2 o.microsoft.com/fwlink/?LinkID=113216).
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
-\par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
+\par \hich\af2\dbch\af31505\loch\f2     None.  You canno\hich\af2\dbch\af31505\loch\f2 t pipe objects to this script.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
@@ -638,19 +638,18 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: PVS_Inventory_V5.ps1
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3154381 \hich\af2\dbch\af31505\loch\f2         VERSION}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16003468 \hich\af2\dbch\af31505\loch\f2 : 5.10}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3154381 \hich\af2\dbch\af31505\loch\f2         VERSION}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid735408 \hich\af2\dbch\af31505\loch\f2 : 5.12}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid11558710\charrsid11558710 
-\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster, Sr. Solutions Architect at Choice Solutions
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5405950 \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16003468 \hich\af2\dbch\af31505\loch\f2 Dec}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid3154381 \hich\af2\dbch\af31505\loch\f2 ember }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16003468 \hich\af2\dbch\af31505\loch\f2 16}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 
-\hich\af2\dbch\af31505\loch\f2 , 2016
+\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster, Sr. Solutions Architect at Choi\hich\af2\dbch\af31505\loch\f2 ce Solutions
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5405950 \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid735408 \hich\af2\dbch\af31505\loch\f2 February 21, 2017}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid11558710\charrsid11558710 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default v\hich\af2\dbch\af31505\loch\f2 alues.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\\hich\af2\dbch\af31505\loch\f2 UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par \hich\af2\dbch\af31505\loch\f2     AdminAddress = LocalHost
 \par 
@@ -660,22 +659,22 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ------\hich\af2\dbch\af31505\loch\f2 -------------------- EXAMPLE 2 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1 -PDF
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl W\hich\af2\dbch\af31505\loch\f2 ebster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par \hich\af2\dbch\af31505\loch\f2     AdminAddress = LocalHost
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for th\hich\af2\dbch\af31505\loch\f2 e User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXA\hich\af2\dbch\af31505\loch\f2 MPLE 3 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1 -TEXT
 \par 
@@ -685,37 +684,37 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Na\hich\af2\dbch\af31505\loch\f2 me.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     Lo\hich\af2\dbch\af31505\loch\f2 calHost for AdminAddress.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1 -HTML
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all defau\hich\af2\dbch\af31505\loch\f2 lt values and save the document as an HTML file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3679694 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as an HTML file.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microso\hich\af2\dbch\af31505\loch\f2 ft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3679694 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = A\hich\af2\dbch\af31505\loch\f2 dministrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page fo\hich\af2\dbch\af31505\loch\f2 rmat.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 PVS_Inventory_V5.ps1 -Hardware
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1 -Hardware
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and add additional information for each server about its }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3679694 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 hardware.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3679694 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\\hich\af2\dbch\af31505\loch\f2 Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\\hich\af2\dbch\af31505\loch\f2 Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -723,21 +722,21 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPL\hich\af2\dbch\af31505\loch\f2 E 6 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V5.ps1 -CompanyName "Carl Webster Consulting" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3679694 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 -CoverPage "Mod" -UserName "Carl Webster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2         Mod for the \hich\af2\dbch\af31505\loch\f2 Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Carl Webster for the User Name.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V5.ps1 -CN "Carl Webster Consulting" -CP "Mod" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3679694 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 -UN "Carl Webster" -AdminAddres\hich\af2\dbch\af31505\loch\f2 s PVS1
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 -UN "Carl Webster" -AdminAddress PVS1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
@@ -746,7 +745,7 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2         PVS1 for AdminAddress.
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAM\hich\af2\dbch\af31505\loch\f2 PLE 8 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V5.ps1 -CN "Carl Webster Consulting" -CP "Mod" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3679694 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 -UN "Carl Webster" -AdminAddress PVS1 -User cwebster -Domain WebstersLab -Password }{\rtlch\fcs1 \af2\afs18 
@@ -754,16 +753,16 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 Abc123!@#
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl We\hich\af2\dbch\af31505\loch\f2 bster Consulting for the Company Name (alias CN).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for t\hich\af2\dbch\af31505\loch\f2 he Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
 \par \hich\af2\dbch\af31505\loch\f2         PVS1 for AdminAddress.
 \par \hich\af2\dbch\af31505\loch\f2         cwebster for User.
 \par \hich\af2\dbch\af31505\loch\f2         WebstersLab for Domain.
-\par \hich\af2\dbch\af31505\loch\f2         Abc123!\hich\af2\dbch\af31505\loch\f2 @# for Password.
+\par \hich\af2\dbch\af31505\loch\f2         Abc123!@# for Password.
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  -------------------------- EXAMPLE 9 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V5.ps1 -CN "Carl Webster Consulting" -CP "Mod" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3679694 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 -UN "Carl Webster" -AdminAddress PVS1 -User cwebster
@@ -818,14 +817,14 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3679694 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\\hich\af2\dbch\af31505\loch\f2 Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\O\hich\af2\dbch\af31505\loch\f2 ffice\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Output file will be saved in the path \\\\FileServer\\Sha\hich\af2\dbch\af31505\loch\f2 reName
+\par \hich\af2\dbch\af31505\loch\f2     Output file will be saved in the path \\\\FileServer\\Shar\hich\af2\dbch\af31505\loch\f2 eName
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
@@ -848,18 +847,18 @@ PVS_Inventory_V5.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] [-EndDate <Date
 \par \hich\af2\dbch\af31505\loch\f2     Script will use the email server mail.domain.tld, sending from }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3679694 \hich\af2\dbch\af31505\loch\f2  HYPERL\hich\af2\dbch\af31505\loch\f2 
 INK "mailto:}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3679694\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 XDAdmin@domain.tld}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3679694 \hich\af2\dbch\af31505\loch\f2 " }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9466969 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4c0000006d00610069006c0074006f003a0058004400410064006d0069006e00400064006f006d00610069006e002e0074006c0064000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4c0000006d00610069006c0074006f003a0058004400410064006d0069006e00400064006f006d00610069006e002e0074006c0064000000795881f43b1d7f48af2c825dc485276300000000a5ab000300000000}}
 }{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf17\insrsid3679694\charrsid5318453 \hich\af2\dbch\af31505\loch\f2 XDAdmin@domain.tld}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 , }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3679694 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 sending to ITGroup@domain.tld.
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, t\hich\af2\dbch\af31505\loch\f2 he user will be prompted }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3679694 
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, \hich\af2\dbch\af31505\loch\f2 the user will be prompted }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3679694 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 to enter valid credentials.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1 -SmtpServer smtp.office365.com -SmtpPort 587 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3679694 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 -UseSSL -From Webster@CarlWebster\hich\af2\dbch\af31505\loch\f2 .com -To ITGroup@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11558710\charrsid11558710 \hich\af2\dbch\af31505\loch\f2 -UseSSL -From Webster@CarlWebste\hich\af2\dbch\af31505\loch\f2 r.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3679694 
@@ -932,7 +931,7 @@ a7e7c0000000360100000b00000000000000000000000000300100005f72656c732f2e72656c7350
 617020786d6c6e733a613d22687474703a2f2f736368656d61732e6f70656e786d6c666f726d6174732e6f72672f64726177696e676d6c2f323030362f6d6169
 6e22206267313d226c743122207478313d22646b3122206267323d226c743222207478323d22646b322220616363656e74313d22616363656e74312220616363
 656e74323d22616363656e74322220616363656e74333d22616363656e74332220616363656e74343d22616363656e74342220616363656e74353d22616363656e74352220616363656e74363d22616363656e74362220686c696e6b3d22686c696e6b2220666f6c486c696e6b3d22666f6c486c696e6b222f3e}
-{\*\latentstyles\lsdstimax372\lsdlockeddef0\lsdsemihiddendef0\lsdunhideuseddef0\lsdqformatdef0\lsdprioritydef99{\lsdlockedexcept \lsdqformat1 \lsdpriority0 \lsdlocked0 Normal;\lsdqformat1 \lsdlocked0 heading 1;\lsdqformat1 \lsdlocked0 heading 2;
+{\*\latentstyles\lsdstimax374\lsdlockeddef0\lsdsemihiddendef0\lsdunhideuseddef0\lsdqformatdef0\lsdprioritydef99{\lsdlockedexcept \lsdqformat1 \lsdpriority0 \lsdlocked0 Normal;\lsdqformat1 \lsdlocked0 heading 1;\lsdqformat1 \lsdlocked0 heading 2;
 \lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 3;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 4;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 5;
 \lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 6;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 7;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 8;
 \lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 9;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 1;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 2;
@@ -988,8 +987,8 @@ a7e7c0000000360100000b00000000000000000000000000300100005f72656c732f2e72656c7350
 \lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 4;\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 5;\lsdpriority47 \lsdlocked0 List Table 2 Accent 5;\lsdpriority48 \lsdlocked0 List Table 3 Accent 5;
 \lsdpriority49 \lsdlocked0 List Table 4 Accent 5;\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 5;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 5;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 5;
 \lsdpriority46 \lsdlocked0 List Table 1 Light Accent 6;\lsdpriority47 \lsdlocked0 List Table 2 Accent 6;\lsdpriority48 \lsdlocked0 List Table 3 Accent 6;\lsdpriority49 \lsdlocked0 List Table 4 Accent 6;
-\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 6;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 6;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 6;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Mention;}}{\*\datastore 0105000002000000
-180000004d73786d6c322e534158584d4c5265616465722e362e3000000000000000000000060000
+\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 6;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 6;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 6;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Mention;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Hyperlink;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Hashtag;}}{\*\datastore 0105000002000000180000004d73786d6c322e534158584d4c5265616465722e362e3000000000000000000000060000
 d0cf11e0a1b11ae1000000000000000000000000000000003e000300feff090006000000000000000000000001000000010000000000000000100000feffffff00000000feffffff0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
@@ -998,8 +997,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000c072
-3a1ade57d201feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000080f2
+cf402989d201feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/PVS_V5_Script_ChangeLog.txt
+++ b/PVS_V5_Script_ChangeLog.txt
@@ -6,6 +6,11 @@
 #Thanks to Michael B. Smith, Joe Shonk and Stephane Thirion
 #for testing and fine-tuning tips 
 
+#Version 5.12 21-Feb-2017 
+#	Added back "Use Datacenter licenses for desktops if no Desktop licenses are available" to Farm properties
+#		This was added back in PVS 7.13
+#	Fixed French wording for Table of Contents 2 (Thanks to David Rouquier)
+
 #Version 5.11 31-Jan-2017
 #	Added support for "Configured for XenServer vDisk caching" to Target Devices and Hosts
 #	Added "Datacenter" for VMware Hosts


### PR DESCRIPTION
#Version 5.12 21-Feb-2017 
#	Added back "Use Datacenter licenses for desktops if no Desktop licenses are available" to Farm properties
#		This was added back in PVS 7.13
#	Fixed French wording for Table of Contents 2 (Thanks to David Rouquier)