### PR TITLE
Final update for 5.20

### DIFF
--- a/PVS_Inventory_V5.ps1
+++ b/PVS_Inventory_V5.ps1
@@ -439,9 +439,9 @@
 	No objects are output from this script.  This script creates a Word or PDF document.
 .NOTES
 	NAME: PVS_Inventory_V5.ps1
-	VERSION: 5.19
+	VERSION: 5.20
 	AUTHOR: Carl Webster
-	LASTEDIT: December 17, 2019
+	LASTEDIT: December 20, 2019
 #>
 
 #endregion
@@ -582,6 +582,12 @@ Param(
 
 #HTML functions and sample text contributed by Ken Avram October 2014
 
+#Version 5.20 20-Dec-2019
+#	Fixed an extra set of {} on a Default Switch statement
+#		Default {{$xType = "Undefined"; Break }}
+#		This caused "$xType = "Undefined"; Break" to show in the console
+#	Tested with PVS 1912
+#	
 #Version 5.19 17-Dec-2019
 #	Fix Swedish Table of Contents (Thanks to Johan Kallio)
 #		From 
@@ -5515,7 +5521,7 @@ Function OutputAuditTrail
 				11 		{$xType = "Store"; Break }
 				12 		{$xType = "System"; Break }
 				13 		{$xType = "UserGroup"; Break }
-				Default { {$xType = "Undefined"; Break }}
+				Default {$xType = "Undefined"; Break }
 			}
 			If($MSWord -or $PDF)
 			{

--- a/PVS_Inventory_V5_ReadMe.rtf
+++ b/PVS_Inventory_V5_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -118,11 +118,11 @@ Hyperlink;}}{\*\listtable{\list\listtemplateid-1612023500\listhybrid{\listlevel\
 \fi-180\li6480\lin6480 }{\listname ;}\listid2008631076}}{\*\listoverridetable{\listoverride\listid558714133\listoverridecount0\ls1}{\listoverride\listid676005662\listoverridecount0\ls2}{\listoverride\listid1940482595\listoverridecount0\ls3}
 {\listoverride\listid872425844\listoverridecount0\ls4}{\listoverride\listid2008631076\listoverridecount0\ls5}{\listoverride\listid314996233\listoverridecount0\ls6}{\listoverride\listid1217358328\listoverridecount0\ls7}{\listoverride\listid642077380
 \listoverridecount0\ls8}}{\*\rsidtbl \rsid153717\rsid401028\rsid735408\rsid2246377\rsid2584501\rsid2585069\rsid3085909\rsid3154381\rsid3345712\rsid3478208\rsid3679694\rsid4090611\rsid4160880\rsid4482658\rsid5318453\rsid5405950\rsid5661568\rsid5990872
-\rsid7282308\rsid8018432\rsid8982599\rsid9466969\rsid10386082\rsid11218240\rsid11558710\rsid12087820\rsid12126521\rsid12282547\rsid12988199\rsid13253201\rsid13265712\rsid13762634\rsid14316788\rsid14772334\rsid14894181\rsid16003468}{\mmathPr\mmathFont34
-\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo4\dy1\hr13\min41}{\revtim\yr2019\mo9\dy9\hr7\min9}{\version28}{\edmins132}{\nofpages15}
-{\nofwords4377}{\nofchars24950}{\nofcharsws29269}{\vern111}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid7282308\rsid7954372\rsid8018432\rsid8982599\rsid9466969\rsid10386082\rsid11218240\rsid11558710\rsid12087820\rsid12126521\rsid12282547\rsid12988199\rsid13253201\rsid13265712\rsid13762634\rsid14316788\rsid14772334\rsid14894181\rsid16003468}{\mmathPr
+\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo4\dy1\hr13\min41}{\revtim\yr2019\mo12\dy20\hr13\min42}{\version29}{\edmins133}
+{\nofpages15}{\nofwords4377}{\nofchars24950}{\nofcharsws29269}{\vern119}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot14894181 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot14894181 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -136,7 +136,8 @@ Hyperlink;}}{\*\listtable{\list\listtemplateid-1612023500\listhybrid{\listlevel\
 \par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f31506\insrsid2585069\charrsid2246377 \hich\af31506\dbch\af31505\loch\f31506 NOTE: This script }{\rtlch\fcs1 \ab\af37 
 \ltrch\fcs0 \b\f31506\insrsid4090611\charrsid2246377 \hich\af31506\dbch\af31505\loch\f31506 requires }{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f31506\insrsid2585069\charrsid2246377 \hich\af31506\dbch\af31505\loch\f31506 PowerShell V3 }{\rtlch\fcs1 \ab\af37 
 \ltrch\fcs0 \b\f31506\insrsid4090611\charrsid2246377 \hich\af31506\dbch\af31505\loch\f31506 or later}{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f31506\insrsid2585069\charrsid2246377 .
-\par }{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f31506\insrsid4090611\charrsid2246377 \hich\af31506\dbch\af31505\loch\f31506 NOTE: Word 2007 is no longer supported.}{\rtlch\fcs1 \af37 \ltrch\fcs0 \f31506\insrsid4090611\charrsid2246377 
+\par }{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f31506\insrsid4090611\charrsid2246377 \hich\af31506\dbch\af31505\loch\f31506 NOTE: Word 2007\hich\af31506\dbch\af31505\loch\f31506  is no longer supported.}{\rtlch\fcs1 \af37 \ltrch\fcs0 
+\f31506\insrsid4090611\charrsid2246377 
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf21\insrsid2585069 \hich\af43\dbch\af31505\loch\f43 Support for non-English Versions of Microsoft Word
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
@@ -173,14 +174,15 @@ For Windows 8.x, Server 2012 and Server 2012 R2}{\rtlch\fcs1 \af0\afs22 \ltrch\f
 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2584501 \hich\af31506\dbch\af31505\loch\f31506 :}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid2584501\charrsid2584501 
 \par }\pard \ltrpar\s17\ql \li1440\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin1440\itap0\pararsid2584501 {\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid2585069\charrsid2584501 \hich\af31506\dbch\af31505\loch\f31506 %systemroot%\\Microsoft.NET\\
 Framework\\v4.0.30319\\installutil.exe }{\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid735408 \hich\af31506\dbch\af31505\loch\f31506 "}{\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid3085909\charrsid2584501 
-\hich\af37\dbch\af31505\loch\f37 %ProgramFiles%\\Citrix\\Provisioning Services Console}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid3085909\charrsid2584501 \\}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid13265712\charrsid13265712 
-\hich\af37\dbch\af31505\loch\f37 Citrix.PVS.SnapIn}{\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid735408 \hich\af37\dbch\af31505\loch\f37 .dll"}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid2585069\charrsid2584501 
+\hich\af37\dbch\af31505\loch\f37 %ProgramFiles%\\Citrix\\\hich\af37\dbch\af31505\loch\f37 Provisioning Services Console}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid3085909\charrsid2584501 \\}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 
+\b\f37\fs22\insrsid13265712\charrsid13265712 \hich\af37\dbch\af31505\loch\f37 Citrix.PVS.SnapIn}{\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid735408 \hich\af37\dbch\af31505\loch\f37 .dll"}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 
+\b\f31506\fs22\insrsid2585069\charrsid2584501 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0 \ltrch\fcs0 \f2\insrsid2585069\charrsid2584501 \hich\af2\dbch\af31505\loch\f2 o\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\nowidctlpar\wrapdefault\faauto\ls8\ilvl1\rin0\lin1440\itap0\pararsid2584501 {
 \rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid2585069\charrsid2584501 \hich\af43\dbch\af31505\loch\f43 For 64-bit}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid2584501\charrsid2584501 \hich\af43\dbch\af31505\loch\f43 :
-\par }\pard \ltrpar\s17\ql \li1440\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin1440\itap0\pararsid2584501 {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid2585069\charrsid2584501 \hich\af31506\dbch\af31505\loch\f31506 %systemroot%\\
-\hich\af31506\dbch\af31505\loch\f31506 Microsoft.NET\\Framework64\\v4.0.30319\\installutil.exe }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid735408 \hich\af31506\dbch\af31505\loch\f31506 "}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 
-\b\f31506\fs22\insrsid3085909\charrsid2584501 \hich\af31506\dbch\af31505\loch\f31506 %ProgramFiles%\\Citrix\\Provisioning Services Console\\}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid13265712\charrsid13265712 \hich\af37\dbch\af31505\loch\f37 
-Citrix.PVS.SnapIn}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid735408 \hich\af31506\dbch\af31505\loch\f31506 .dll"}{\rtlch\fcs1 \ab\af37\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid3085909\charrsid2584501 
+\par }\pard \ltrpar\s17\ql \li1440\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin1440\itap0\pararsid2584501 {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid2585069\charrsid2584501 \hich\af31506\dbch\af31505\loch\f31506 %systemroot%\\Microsoft.NET\\
+Framework64\\v4.0.30319\\installutil.exe }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid735408 \hich\af31506\dbch\af31505\loch\f31506 "}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid3085909\charrsid2584501 
+\hich\af31506\dbch\af31505\loch\f31506 %ProgramFiles%\\Citrix\\Provisioning Services Console\\}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid13265712\charrsid13265712 \hich\af37\dbch\af31505\loch\f37 Citrix.PVS.SnapIn}{\rtlch\fcs1 \af0\afs22 
+\ltrch\fcs0 \b\f31506\fs22\insrsid735408 \hich\af31506\dbch\af31505\loch\f31506 .dll"}{\rtlch\fcs1 \ab\af37\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid3085909\charrsid2584501 
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
 \ab\af37\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid2584501 \hich\af37\dbch\af31505\loch\f37 Note:}{\rtlch\fcs1 \ab\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2584501 \hich\af37\dbch\af31505\loch\f37 \hich\f37 
  All lines are one line. If you copy and paste into a command prompt, watch for the smart quotes. If you get an \'93\loch\f37 \hich\f37 invalid URL\'94\loch\f37  error, paste the text into Notepad and change the smart quotes to regular double quotes.}{
@@ -196,8 +198,8 @@ Citrix.PVS.SnapIn}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid7354
 \ai\af0\afs22 \ltrch\fcs0 \i\f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 PVS_Inventory_V}{\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \i\f31506\fs22\insrsid14772334 \hich\af31506\dbch\af31505\loch\f31506 5}{\rtlch\fcs1 
 \ai\af0\afs22 \ltrch\fcs0 \i\f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 .ps1}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 
  in your PowerShell scripts folder. 
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 2.\tab}\hich\af31506\dbch\af31505\loch\f31506 From the PowerShell prompt,
-\hich\af31506\dbch\af31505\loch\f31506  change to your PowerShell scripts. 
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 2.\tab}\hich\af31506\dbch\af31505\loch\f31506 
+From the PowerShell prompt, change to your PowerShell scripts. 
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 3.\tab}\hich\af31506\dbch\af31505\loch\f31506 From the PowerShell prompt, type in:
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \i\f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 a.\tab}}\pard \ltrpar
 \ql \fi-360\li1440\ri0\nowidctlpar\wrapdefault\faauto\ls7\ilvl1\rin0\lin1440\itap0\pararsid14894181 {\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \i\f31506\fs22\insrsid2585069\charrsid13253201 .\\\hich\af31506\dbch\af31505\loch\f31506 PVS_Inventory_V}{
@@ -206,14 +208,14 @@ Citrix.PVS.SnapIn}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid7354
 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 .}{\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \i\f31506\fs22\insrsid2585069\charrsid13253201 
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 4.\tab}}\pard \ltrpar
 \ql \fi-720\li1080\ri0\nowidctlpar\wrapdefault\faauto\ls7\rin0\lin1080\itap0\pararsid14894181 {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 
-By default, a Microsoft Word document is created named after the PVS Farm.
+By default, a Microsoft Word document is created named after the P\hich\af31506\dbch\af31505\loch\f31506 VS Farm.
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 5.\tab}\hich\af31506\dbch\af31505\loch\f31506 If you use the \hich\f31506 \endash \loch\f31506 
-PDF option, a PDF file is created named\hich\af31506\dbch\af31505\loch\f31506  after the PVS Farm.}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid14894181\charrsid13253201 
+PDF option, a PDF file is created named after the PVS Farm.}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid14894181\charrsid13253201 
 \par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 \hich\af37\dbch\af31505\loch\f37 To run the script remotely, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid153717 \hich\af37\dbch\af31505\loch\f37 
 run the script with the following parameters:}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid153717\charrsid153717 .\\\hich\af37\dbch\af31505\loch\f37 PVS_Inventory_V5.ps1 \hich\f37 \endash \loch\f37 AdminAddress PVS77Server \hich\f37 \endash \loch\f37 User UserName \hich\f37 \endash 
-\loch\f37 Domain ADDomain \hich\f37 \endash \loch\f37 Password PasswordforUserName}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid12282547\charrsid153717 
+\loch\f37 Domain ADDomain \hich\f37 \endash \loch\f37 Password Pa\hich\af37\dbch\af31505\loch\f37 sswordforUserName}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid12282547\charrsid153717 
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Full help text is available.
 \par }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Get-Help .\\PVS_Inventory_V}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid153717 \hich\af37\dbch\af31505\loch\f37 5}{\rtlch\fcs1 
 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 .ps1 \hich\f37 \endash \loch\f37 full
@@ -241,22 +243,23 @@ PVS_Inventory_V5.ps1 [-AdminAddress <String\hich\af2\dbch\af31505\loch\f2 >] [-U
  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyAddress <String>] [-CompanyEmail <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 [-CompanyFax <String>] [-CompanyName <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 <String>] [-UserName <String>] [-MSWord] [-StartDate <DateTime>] [-EndDate}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5661568 \hich\af2\dbch\af31505\loch\f2  
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 <String>] [-UserName <String>] [-MSWord] [-St\hich\af2\dbch\af31505\loch\f2 artDate <DateTime>] [-EndDate}{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 \hich\af2\dbch\af31505\loch\f2  
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2     <DateTime>] [-AddDateTime] [-Folder <String>] [-Hardware] [-Dev] [-ScriptInfo] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \\\hich\af2\dbch\af31505\loch\f2 
-PVS_Inventory_V5.ps1 [-AdminAddress <String>] [-User <S\hich\af2\dbch\af31505\loch\f2 tring>] [-Domain }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
+PVS_Inventory_V5.ps1 [-AdminAddress <String>] [-User <String>] [-Domain }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 <String>] [-Password}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 \hich\af2\dbch\af31505\loch\f2 
- }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyAddress <String>] [-CompanyEmail <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
+ }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 <S\hich\af2\dbch\af31505\loch\f2 tring>] [-CompanyAddress <String>] [-CompanyEmail <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5661568 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 [-CompanyFax <String>] [-CompanyName <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 <String>] [-UserName <String>] [-HTML] [-MSWord] [-PDF] [\hich\af2\dbch\af31505\loch\f2 -Text] [-StartDate}{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2     <DateTime>] [-EndDate <DateTime>] [-AddDateTime] [-Folder <String>] [-Hardware] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
-
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 <String>] [-UserName <String>] [-HTML] [-MSWord] [-PDF] [-Text] [-StartDate}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5661568 \hich\af2\dbch\af31505\loch\f2  
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2     <DateTime>] [-EndDate\hich\af2\dbch\af31505\loch\f2  <DateTime>] [-AddDateTime] [-Folder <String>] [-Hardware] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5661568 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 -SmtpServer <String> [-SmtpPort}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 <Int32>] [-UseSSL] -From <String> -To <String> [-Dev] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
 
@@ -267,16 +270,16 @@ PVS_Inventory_V5.ps1 [-AdminAddress <String>] [-User <String>] [-Domain }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 <String>] [-Password}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 \hich\af2\dbch\af31505\loch\f2 
  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyAddress <String>] [-CompanyEmail <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 [-CompanyFax <String>] [-CompanyName <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 <S\hich\af2\dbch\af31505\loch\f2 tring>] [-UserName <String>] [-PDF] [-StartDate <DateTime>] [-EndDate}{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5661568 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 <String>] [-UserName <String>] [-PDF] [-StartDate <DateTime>] [-EndDate}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5661568 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 [-AddDateTime] [-Folder <String>] [-Hardware] [-Dev] [-ScriptInfo] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5661568 \hich\af2\dbch\af31505\loch\f2     
 \par \hich\af2\dbch\af31505\loch\f2     [}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 <CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \\\hich\af2\dbch\af31505\loch\f2 
-PVS_Inventory_V5.ps1 [-AdminAddress <String>] [-\hich\af2\dbch\af31505\loch\f2 User <String>] [-Domain }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
+PVS_Inventory_V5.ps1 [-AdminAddress <String>] [-User <St\hich\af2\dbch\af31505\loch\f2 ring>] [-Domain }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 <String>] [-Password}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 \hich\af2\dbch\af31505\loch\f2 
  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 <String>] [-HTML] [-StartDate <DateTime>] [-EndDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 [-AddDateTime] [-Folder <String>] [-Hardware]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
@@ -285,7 +288,7 @@ PVS_Inventory_V5.ps1 [-AdminAddress <String>] [-\hich\af2\dbch\af31505\loch\f2 U
 \par \hich\af2\dbch\af31505\loch\f2     [}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 <CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \\\hich\af2\dbch\af31505\loch\f2 
-PVS_Inventory_V5.ps1 [-A\hich\af2\dbch\af31505\loch\f2 dminAddress <String>] [-User <String>] [-Domain }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
+PVS_Inventory_V5.ps1 [-AdminAddr\hich\af2\dbch\af31505\loch\f2 ess <String>] [-User <String>] [-Domain }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 <String>] [-Password}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 \hich\af2\dbch\af31505\loch\f2 
  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 <String>] [-Text] [-StartDate <DateTime>] [-EndDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2 [-AddDateTime] [-Folder <String>] [-Hardware]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
@@ -294,12 +297,12 @@ PVS_Inventory_V5.ps1 [-A\hich\af2\dbch\af31505\loch\f2 dminAddress <String>] [-U
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
-\par \hich\af2\dbch\af31505\loch\f2     Cr\hich\af2\dbch\af31505\loch\f2 eates an inventory of a Citrix PVS 7.x Farm using Microsoft PowerShell, Word,
+\par \hich\af2\dbch\af31505\loch\f2     Creates an\hich\af2\dbch\af31505\loch\f2  inventory of a Citrix PVS 7.x Farm using Microsoft PowerShell, Word,
 \par \hich\af2\dbch\af31505\loch\f2     plain text or HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the script. This script will output in Text and HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a PVS Server. This script \hich\af2\dbch\af31505\loch\f2 was developed and run
+\par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a PVS Server. This script was deve\hich\af2\dbch\af31505\loch\f2 loped and run
 \par \hich\af2\dbch\af31505\loch\f2     from a Windows 8.1 VM.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     You can run this script remotely using the -AdminAddress (AA) parameter.
@@ -732,17 +735,16 @@ PVS_Inventory_V5.ps1 [-A\hich\af2\dbch\af31505\loch\f2 dminAddress <String>] [-U
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par \hich\af2\dbch\af31505\loch\f2         NAME: PVS_Inventory_V5.ps1
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12126521 \hich\af2\dbch\af31505\loch\f2         VERSION: 5.1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13762634 \hich\af2\dbch\af31505\loch\f2 8}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12126521 \hich\af2\dbch\af31505\loch\f2         VERSION: 5.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7954372 \hich\af2\dbch\af31505\loch\f2 20}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5661568\charrsid5661568 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster, Sr. Solutions Architect at Choice Solutions
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13762634 \hich\af2\dbch\af31505\loch\f2 September 9}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3478208 \hich\af2\dbch\af31505\loch\f2 , 2019}{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7954372 \hich\af2\dbch\af31505\loch\f2 December 20, 2019}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     --------------------------\hich\af2\dbch\af31505\loch\f2  EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     W\hich\af2\dbch\af31505\loch\f2 ill use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par \hich\af2\dbch\af31505\loch\f2     AdminAddress = LocalHost
@@ -755,18 +757,18 @@ PVS_Inventory_V5.ps1 [-A\hich\af2\dbch\af31505\loch\f2 dminAddress <String>] [-U
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2\hich\af2\dbch\af31505\loch\f2  --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1 -PDF
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a PDF \hich\af2\dbch\af31505\loch\f2 file.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a PDF file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Ad\hich\af2\dbch\af31505\loch\f2 ministrator
 \par \hich\af2\dbch\af31505\loch\f2     AdminAddress = LocalHost
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator fo\hich\af2\dbch\af31505\loch\f2 r the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
 \par 
 \par 
@@ -783,11 +785,11 @@ PVS_Inventory_V5.ps1 [-A\hich\af2\dbch\af31505\loch\f2 dminAddress <String>] [-U
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ----------------\hich\af2\dbch\af31505\loch\f2 ---------- EXAMPLE 4 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1 -HTML
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all def\hich\af2\dbch\af31505\loch\f2 ault values and save the document as an HTML file.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as an HTML file.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
 \par 
@@ -798,43 +800,43 @@ PVS_Inventory_V5.ps1 [-A\hich\af2\dbch\af31505\loch\f2 dminAddress <String>] [-U
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V5.ps1 -Hardware
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and add addit\hich\af2\dbch\af31505\loch\f2 ional information for each server about its
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and add additional information for each server about its
 \par \hich\af2\dbch\af31505\loch\f2     hardware.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for\hich\af2\dbch\af31505\loch\f2  the User Name.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\\hich\af2\dbch\af31505\loch\f2 >PS C:\\PSScript .\\PVS_Inventory_V5.ps1 -CompanyName "Carl Webster Consulting"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V5.ps1 -CompanyName "Carl Webster Consulting"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage "Mod" -UserName "Carl Webster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webs\hich\af2\dbch\af31505\loch\f2 ter Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster f\hich\af2\dbch\af31505\loch\f2 or the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V5.ps1 -CN "Carl Webster Consulting" -CP "Mod"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\\hich\af2\dbch\af31505\loch\f2 PVS_Inventory_V5.ps1 -CN "Carl Webster Consulting" -CP "Mod"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5661568\charrsid5661568 \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster" -AdminAddress PVS1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster fo\hich\af2\dbch\af31505\loch\f2 r the User Name (alias UN).
 \par \hich\af2\dbch\af31505\loch\f2         PVS1 for AdminAddress.
 \par 
 \par 
@@ -843,16 +845,16 @@ PVS_Inventory_V5.ps1 [-A\hich\af2\dbch\af31505\loch\f2 dminAddress <String>] [-U
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V5.ps1 -CN "Carl Webster Consulting" -CP "Mod"
-\par \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster" -AdminAddress PVS1 -User cwebster -Domain WebstersLab
-\par \hich\af2\dbch\af31505\loch\f2     -Password Abc12\hich\af2\dbch\af31505\loch\f2 3!@#
+\par \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster" -AdminAddres\hich\af2\dbch\af31505\loch\f2 s PVS1 -User cwebster -Domain WebstersLab
+\par \hich\af2\dbch\af31505\loch\f2     -Password Abc123!@#
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
-\par \hich\af2\dbch\af31505\loch\f2         PVS1 for AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2         P\hich\af2\dbch\af31505\loch\f2 VS1 for AdminAddress.
 \par \hich\af2\dbch\af31505\loch\f2         cwebster for User.
-\par \hich\af2\dbch\af31505\loch\f2         Webs\hich\af2\dbch\af31505\loch\f2 tersLab for Domain.
+\par \hich\af2\dbch\af31505\loch\f2         WebstersLab for Domain.
 \par \hich\af2\dbch\af31505\loch\f2         Abc123!@# for Password.
 \par 
 \par 
@@ -1066,7 +1068,7 @@ a7e7c0000000360100000b00000000000000000000000000300100005f72656c732f2e72656c7350
 617020786d6c6e733a613d22687474703a2f2f736368656d61732e6f70656e786d6c666f726d6174732e6f72672f64726177696e676d6c2f323030362f6d6169
 6e22206267313d226c743122207478313d22646b3122206267323d226c743222207478323d22646b322220616363656e74313d22616363656e74312220616363
 656e74323d22616363656e74322220616363656e74333d22616363656e74332220616363656e74343d22616363656e74342220616363656e74353d22616363656e74352220616363656e74363d22616363656e74362220686c696e6b3d22686c696e6b2220666f6c486c696e6b3d22666f6c486c696e6b222f3e}
-{\*\latentstyles\lsdstimax377\lsdlockeddef0\lsdsemihiddendef0\lsdunhideuseddef0\lsdqformatdef0\lsdprioritydef99{\lsdlockedexcept \lsdqformat1 \lsdpriority0 \lsdlocked0 Normal;\lsdqformat1 \lsdlocked0 heading 1;\lsdqformat1 \lsdlocked0 heading 2;
+{\*\latentstyles\lsdstimax376\lsdlockeddef0\lsdsemihiddendef0\lsdunhideuseddef0\lsdqformatdef0\lsdprioritydef99{\lsdlockedexcept \lsdqformat1 \lsdpriority0 \lsdlocked0 Normal;\lsdqformat1 \lsdlocked0 heading 1;\lsdqformat1 \lsdlocked0 heading 2;
 \lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 3;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 4;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 5;
 \lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 6;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 7;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 8;
 \lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 9;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 1;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 2;
@@ -1123,8 +1125,8 @@ a7e7c0000000360100000b00000000000000000000000000300100005f72656c732f2e72656c7350
 \lsdpriority49 \lsdlocked0 List Table 4 Accent 5;\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 5;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 5;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 5;
 \lsdpriority46 \lsdlocked0 List Table 1 Light Accent 6;\lsdpriority47 \lsdlocked0 List Table 2 Accent 6;\lsdpriority48 \lsdlocked0 List Table 3 Accent 6;\lsdpriority49 \lsdlocked0 List Table 4 Accent 6;
 \lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 6;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 6;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 6;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Mention;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Hyperlink;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Hashtag;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Unresolved Mention;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Link;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Link Error;}}{\*\datastore 0105000002000000180000004d73786d6c322e534158584d4c5265616465722e362e3000000000000000000000060000
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Hyperlink;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Hashtag;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Unresolved Mention;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Link;}}{\*\datastore 01050000
+02000000180000004d73786d6c322e534158584d4c5265616465722e362e3000000000000000000000060000
 d0cf11e0a1b11ae1000000000000000000000000000000003e000300feff090006000000000000000000000001000000010000000000000000100000feffffff00000000feffffff0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
@@ -1133,8 +1135,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000d0d7
-be670767d501feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000902a
+f88c6db7d501feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/PVS_V5_Script_ChangeLog.txt
+++ b/PVS_V5_Script_ChangeLog.txt
@@ -5,6 +5,12 @@
 #This script written for "Benji", March 19, 2012
 #Thanks to Michael B. Smith, Joe Shonk and Stephane Thirion for testing and fine-tuning tips 
 
+#Version 5.20 20-Dec-2019
+#	Fixed an extra set of {} on a Default Switch statement
+#		Default {{$xType = "Undefined"; Break }}
+#		This caused "$xType = "Undefined"; Break" to show in the console
+#	Tested with PVS 1912
+
 #Version 5.19 17-Dec-2019
 #	Fix Swedish Table of Contents (Thanks to Johan Kallio)
 #		From 


### PR DESCRIPTION
#Version 5.20 20-Dec-2019
#	Fixed an extra set of {} on a Default Switch statement
#		Default {{$xType = "Undefined"; Break }}
#		This caused "$xType = "Undefined"; Break" to show in the console
#	Tested with PVS 1912