### PR TITLE
Final update for 6.04

### DIFF
--- a/PVS_Inventory_V6_ReadMe.rtf
+++ b/PVS_Inventory_V6_ReadMe.rtf
@@ -1,8 +1,8 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f47\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f48\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
@@ -47,16 +47,16 @@ heading 1;}{\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\li
 Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\kerning32\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink1 \slocked \spriority9 Heading 1 Char;}{\*\cs16 \additive \rtlch\fcs1 \ab\ai\af0\afs28 \ltrch\fcs0 
 \b\i\fs28\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink2 \slocked \ssemihidden \spriority9 Heading 2 Char;}{\s17\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext17 \sqformat \spriority1 \styrsid14894181 No Spacing;}{\*\cs18 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf19 \sbasedon10 \sunhideused \styrsid14894181 
-Hyperlink;}{\*\cs19 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf20\chshdng0\chcfpat0\chcbpat21 \sbasedon10 \ssemihidden \sunhideused \styrsid2307810 Unresolved Mention;}}{\*\listtable{\list\listtemplateid932093020\listhybrid{\listlevel\levelnfc23
-\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
-\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360
-\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+Hyperlink;}{\*\cs19 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf20\chshdng0\chcfpat0\chcbpat21 \sbasedon10 \ssemihidden \sunhideused \styrsid2307810 Unresolved Mention;}}{\*\listtable{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc23\levelnfcn23
+\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
+\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
+{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
 \leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691
 \'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}
 \f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 
 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel
 \levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid100271447}
-{\list\listtemplateid-1612023500\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid-1088912668\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0 
+{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid-1088912668\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0 
 \fi-720\li1080\lin1080 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid1670146738\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0 \fi-720\li1800\lin1800 
 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel
 \levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4
@@ -64,24 +64,24 @@ Hyperlink;}{\*\cs19 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf20\chshdng0\chcfpa
 \leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0
 \levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0
 \levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1
-\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid314996233}{\list\listtemplateid-1236917028\listhybrid{\listlevel\levelnfc23
-\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
-\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360
-\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid314996233}{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc23\levelnfcn23
+\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
+\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
+{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
 \leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691
 \'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}
 \f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 
 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel
 \levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid558714133}
-{\list\listtemplateid-990473222\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li720\lin720 }
-{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
-\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
-\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
-{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
+{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li720\lin720 }{\listlevel
+\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360
+\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
 \'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}
 \f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }
 {\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid642077380}
-{\list\listtemplateid1184951006\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0\levelspace0\levelindent0{\leveltext\leveltemplateid1732811676\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0 
+{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0\levelspace0\levelindent0{\leveltext\leveltemplateid1732811676\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0 
 \fi-720\li1080\lin1080 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23
 \levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
 \levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
@@ -89,8 +89,8 @@ Hyperlink;}{\*\cs19 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf20\chshdng0\chcfpa
 {\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689
 \'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 
 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname 
-;}\listid676005662}{\list\listtemplateid-546045730\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 
-\ltrch\fcs0 \fi-360\li1080\lin1080 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
+;}\listid676005662}{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
+\fi-360\li1080\lin1080 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
 \fi-360\li1800\lin1800 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
 \fi-180\li2520\lin2520 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
 \fi-360\li3240\lin3240 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
@@ -98,7 +98,7 @@ Hyperlink;}{\*\cs19 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf20\chshdng0\chcfpa
 \fi-180\li4680\lin4680 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
 \fi-360\li5400\lin5400 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
 \fi-360\li6120\lin6120 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-180\li6840\lin6840 }{\listname ;}\listid872425844}{\list\listtemplateid1500158440\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid-1088912668
+\fi-180\li6840\lin6840 }{\listname ;}\listid872425844}{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid-1088912668
 \'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0 \fi-720\li1080\lin1080 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698713
 \'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715
 \'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703
@@ -107,7 +107,7 @@ Hyperlink;}{\*\cs19 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf20\chshdng0\chcfpa
 \'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703
 \'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713
 \'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715
-\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid1217358328}{\list\listtemplateid1020826486\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0\levelspace360
+\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid1217358328}{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0\levelspace360
 \levelindent0{\leveltext\leveltemplateid1732811676\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0 \fi-720\li1080\lin1080 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360
 \levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
 \leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689
@@ -115,26 +115,26 @@ Hyperlink;}{\*\cs19 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf20\chshdng0\chcfpa
 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }
 {\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23
 \leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
-\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1940482595}{\list\listtemplateid-1055998564\listhybrid{\listlevel\levelnfc0
-\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0
-\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0
-\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1
-\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
-\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360
-\levelindent0{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
-{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1940482595}{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc0\levelnfcn0
+\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1
+\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
+\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360
+\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
+{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
 \leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
 \leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid2008631076}}{\*\listoverridetable{\listoverride\listid558714133\listoverridecount0\ls1}{\listoverride\listid676005662
 \listoverridecount0\ls2}{\listoverride\listid1940482595\listoverridecount0\ls3}{\listoverride\listid872425844\listoverridecount0\ls4}{\listoverride\listid2008631076\listoverridecount0\ls5}{\listoverride\listid314996233\listoverridecount0\ls6}
 {\listoverride\listid1217358328\listoverridecount0\ls7}{\listoverride\listid642077380\listoverridecount0\ls8}{\listoverride\listid100271447\listoverridecount0\ls9}}{\*\rsidtbl \rsid153717\rsid225946\rsid401028\rsid735408\rsid1919522\rsid2246377
 \rsid2307810\rsid2388634\rsid2584501\rsid2585069\rsid2902022\rsid3085909\rsid3154381\rsid3345712\rsid3478208\rsid3679694\rsid4090611\rsid4160880\rsid4482658\rsid5058413\rsid5185810\rsid5318453\rsid5405950\rsid5661568\rsid5715848\rsid5990872\rsid6241543
-\rsid6767713\rsid7282308\rsid7954372\rsid8018432\rsid8789310\rsid8982599\rsid9466969\rsid10386082\rsid11218240\rsid11558710\rsid12087820\rsid12126521\rsid12282547\rsid12988199\rsid13253201\rsid13265712\rsid13762634\rsid14224466\rsid14316788\rsid14427774
-\rsid14694937\rsid14772334\rsid14894181\rsid15682948\rsid16003468}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}
-{\creatim\yr2014\mo4\dy1\hr13\min41}{\revtim\yr2022\mo2\dy8\hr16\min28}{\version42}{\edmins215}{\nofpages16}{\nofwords4487}{\nofchars25580}{\nofcharsws30007}{\vern41}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
+\rsid6767713\rsid7282308\rsid7954372\rsid8018432\rsid8789310\rsid8982599\rsid9466969\rsid10386082\rsid11218240\rsid11558710\rsid12087820\rsid12126521\rsid12282547\rsid12988199\rsid13253201\rsid13265712\rsid13442966\rsid13762634\rsid14224466\rsid14316788
+\rsid14427774\rsid14694937\rsid14772334\rsid14894181\rsid15682948\rsid15800026\rsid16003468}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}
+{\creatim\yr2014\mo4\dy1\hr13\min41}{\revtim\yr2022\mo3\dy6\hr6\min3}{\version44}{\edmins227}{\nofpages16}{\nofwords4491}{\nofchars25601}{\nofcharsws30032}{\vern43}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
 \paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot14894181 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDYyNjI0NDM0tDA2MzYyNTVX0lEKTi0uzszPAykwrwUAhhWm9ywAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDYyNjI0NDM0tDA2MzYyNTVX0lEKTi0uzszPAymwqAUASQk+cCwAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -194,23 +194,21 @@ From the PowerShell prompt, change to your PowerShell scripts.
 \rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \i\f31506\fs22\insrsid2388634 \hich\af31506\dbch\af31505\loch\f31506 6}{\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \i\f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 .ps1}{\rtlch\fcs1 
 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506  and press }{\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \i\f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 Enter}{
 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 .}{\rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \i\f31506\fs22\insrsid2585069\charrsid13253201 
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 4.\tab}}\pard \ltrpar
-\ql \fi-720\li1080\ri0\nowidctlpar\wrapdefault\faauto\ls7\rin0\lin1080\itap0\pararsid14894181 {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 By default, a}{\rtlch\fcs1 \af0\afs22 
-\ltrch\fcs0 \f31506\fs22\insrsid2388634 \hich\af31506\dbch\af31505\loch\f31506 n HTML }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 document is created named after the PVS Farm.
-
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid2388634\charrsid2388634 \hich\af37\dbch\af31505\loch\f37 5.\tab}}\pard \ltrpar\ql \fi-720\li1080\ri0\nowidctlpar\wrapdefault\faauto\ls7\rin0\lin1080\itap0\pararsid2388634 {
-\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid2388634\charrsid2388634 \hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid2388634 \hich\af37\dbch\af31505\loch\f37 Text}{\rtlch\fcs1 
-\af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid2388634\charrsid2388634 \hich\af37\dbch\af31505\loch\f37  option, a }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid2388634 \hich\af37\dbch\af31505\loch\f37 text}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid2388634\charrsid2388634 \hich\af37\dbch\af31505\loch\f37  file is created named after the PVS Farm.
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid2388634\charrsid2388634 \hich\af37\dbch\af31505\loch\f37 6.\tab}\hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash \loch\f37 
-PDF option, a PDF file is created named after the PVS Farm.
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 7.\tab}}\pard \ltrpar
-\ql \fi-720\li1080\ri0\nowidctlpar\wrapdefault\faauto\ls7\rin0\lin1080\itap0\pararsid14894181 {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 If you use the \hich\f31506 \endash }{
-\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2388634 \hich\af31506\dbch\af31505\loch\f31506 MSWord}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506  option, a }{\rtlch\fcs1 
-\af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2388634 \hich\af31506\dbch\af31505\loch\f31506 Microsoft Word}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 
- file is created named after the PVS Farm.}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid14894181\charrsid13253201 
-\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 
-\par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 \hich\af37\dbch\af31505\loch\f37 To run the script remotely, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid153717 \hich\af37\dbch\af31505\loch\f37 
+\par {\*\bkmkstart _Hlk97191170}{\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid15800026 \hich\af31506\dbch\af31505\loch\f31506 4.\tab}}\pard \ltrpar
+\ql \fi-720\li1080\ri0\nowidctlpar\wrapdefault\faauto\ls7\rin0\lin1080\itap0\pararsid14894181 {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid15800026 \hich\af31506\dbch\af31505\loch\f31506 The script creates an HTML document named after the PV
+\hich\af31506\dbch\af31505\loch\f31506 S Farm by default}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 .
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid15800026 \hich\af37\dbch\af31505\loch\f37 5.\tab}}\pard \ltrpar\ql \fi-720\li1080\ri0\nowidctlpar\wrapdefault\faauto\ls7\rin0\lin1080\itap0\pararsid2388634 {\rtlch\fcs1 
+\af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid15800026 \hich\af37\dbch\af31505\loch\f37 The script creates a text file named after the PVS Farm if you use the -Text option}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid2388634\charrsid2388634 .
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid15800026 \hich\af37\dbch\af31505\loch\f37 6.\tab}}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid15800026 \hich\af37\dbch\af31505\loch\f37 
+The script creates a PDF file named after the PVS Farm if you use the -PDF option}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid2388634\charrsid2388634 .
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid15800026 \hich\af31506\dbch\af31505\loch\f31506 7.\tab}}\pard \ltrpar\ql \fi-720\li1080\ri0\nowidctlpar\wrapdefault\faauto\ls7\rin0\lin1080\itap0\pararsid15800026 {
+\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid15800026 \hich\af31506\dbch\af31505\loch\f31506 The script creates }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 a }{
+\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2388634 \hich\af31506\dbch\af31505\loch\f31506 Microsoft Word}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506  file }{
+\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid15800026 \hich\af31506\dbch\af31505\loch\f31506 n}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 amed after the PVS}{
+\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid15800026 \hich\af31506\dbch\af31505\loch\f31506  }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid15800026 \hich\af31506\dbch\af31505\loch\f31506 Farm}{\rtlch\fcs1 \af0\afs22 
+\ltrch\fcs0 \f31506\fs22\insrsid15800026 \hich\af31506\dbch\af31505\loch\f31506  if you use the -MSWord option.}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid14894181\charrsid15800026 
+\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 {\*\bkmkend _Hlk97191170}
+\par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 {\*\bkmkstart _Hlk97191205}\hich\af37\dbch\af31505\loch\f37 To run the script remotely, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid153717 \hich\af37\dbch\af31505\loch\f37 
 run the script with the following parameters:}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid153717\charrsid153717 .\\\hich\af37\dbch\af31505\loch\f37 PVS_Inventory_V}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid2388634 \hich\af37\dbch\af31505\loch\f37 6}{\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \i\f37\fs22\insrsid153717\charrsid153717 \hich\af37\dbch\af31505\loch\f37 .ps1 \hich\f37 \endash \loch\f37 AdminAddress PVS}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid2388634 \hich\af37\dbch\af31505\loch\f37 2012}{\rtlch\fcs1 
@@ -219,8 +217,8 @@ run the script with the following parameters:}{\rtlch\fcs1 \af37\afs22 \ltrch\fc
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Full help text is available.
 \par }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Get-Help .\\PVS_Inventory_V}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid2388634 \hich\af37\dbch\af31505\loch\f37 6}{\rtlch\fcs1 
 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 .ps1 \hich\f37 \endash \loch\f37 full
-\par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 The help text explains all the p\hich\af37\dbch\af31505\loch\f37 arameters the script accepts.
-\par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12988199 
+\par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 The help text explains all the parameters the script accepts.
+\par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12988199 {\*\bkmkend _Hlk97191205}
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid12988199 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf23\insrsid2307810 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf23\insrsid12988199 
 \hich\af43\dbch\af31505\loch\f43 Help Text
@@ -239,33 +237,33 @@ PVS_Inventory_V6.ps1
 PVS_Inventory_V6.ps1 [-AdminAddress <String>] [-Domain <String>] [-User }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 <String>] [-HTML] [-Text] [-AddDateTime] [-Dev] [-Folder <String>] [-Log] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid14427774 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 [-ScriptInfo] [-ReportFooter] [-StartDate <DateTime>] [-EndDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14427774 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Limit\hich\af2\dbch\af31505\loch\f2 
-TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 [-ScriptInfo] \hich\af2\dbch\af31505\loch\f2 [-ReportFooter] [-StartDate <DateTime>] [-EndDate <DateTime>] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-LimitTargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14427774 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 <String>] [-SmtpPort <Int32>] [-\hich\af2\dbch\af31505\loch\f2 UseSSL] [-From <String>] [-To <String>] }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <Strin\hich\af2\dbch\af31505\loch\f2 
+g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 <String>] [-SmtpPort <Int32>] [-UseSSL] [-From <String>] [-To <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14427774 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
-\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of a Citrix PVS 7.x or later Farm using Microsoft PowerShell, Word,
+\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of a Citrix PVS 7.x or later Farm using Microsoft Powe\hich\af2\dbch\af31505\loch\f2 rShell, Word,
 \par \hich\af2\dbch\af31505\loch\f2     plain text, or HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The default output is now HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     You do NOT have to ru\hich\af2\dbch\af31505\loch\f2 n this script on a PVS Server. This script was developed and run
+\par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a PVS Server. This script was developed and run
 \par \hich\af2\dbch\af31505\loch\f2     from a Windows 10 VM.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     You can run this script remotely using the -AdminAddress (AA) parameter.
+\par \hich\af2\dbch\af31505\loch\f2     You can run this script remotely using the -AdminAddress (\hich\af2\dbch\af31505\loch\f2 AA) parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The PVS Console must be installed on the computer running the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates\hich\af2\dbch\af31505\loch\f2  an output file named after the PVS farm.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after the PVS farm.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word and PDF Document includes a Cover Page, Table of Contents, and Footer.
 \par 
@@ -276,12 +274,12 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par \hich\af2\dbch\af31505\loch\f2         Dutch
 \par \hich\af2\dbch\af31505\loch\f2         English
 \par \hich\af2\dbch\af31505\loch\f2         Finnish
-\par \hich\af2\dbch\af31505\loch\f2         French
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   French
 \par \hich\af2\dbch\af31505\loch\f2         German
 \par \hich\af2\dbch\af31505\loch\f2         Norwegian
 \par \hich\af2\dbch\af31505\loch\f2         Portuguese
 \par \hich\af2\dbch\af31505\loch\f2         Spanish
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Swedish
+\par \hich\af2\dbch\af31505\loch\f2         Swedish
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
@@ -290,7 +288,7 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of AA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    \hich\af2\dbch\af31505\loch\f2 named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -302,24 +300,24 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                $env:UserDomain
+\par \hich\af2\dbch\af31505\loch\f2         Default value                $env:UserD\hich\af2\dbch\af31505\loch\f2 omain
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wild\hich\af2\dbch\af31505\loch\f2 card characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -User <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the user used for the AdminAddress connection.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $env:username
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?        \hich\af2\dbch\af31505\loch\f2             false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Default value                $env:username
+\par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no \hich\af2\dbch\af31505\loch\f2 other output format is selected.
+\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML fil\hich\af2\dbch\af31505\loch\f2 e with an .html extension.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -331,25 +329,25 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?             \hich\af2\dbch\af31505\loch\f2        false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value          \hich\af2\dbch\af31505\loch\f2       False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds a date timestamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2         Adds a date timestamp to \hich\af2\dbch\af31505\loch\f2 the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2         The timestamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       June 1, 2021 at 6PM is 2021-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2         June 1, 2021 at 6PM is 2021-06-01_1800.
 \par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2021-06-01_1800.docx (or .pdf).
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ADT.
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        This parameter has an alias of ADT.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fal\hich\af2\dbch\af31505\loch\f2 se
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
@@ -361,25 +359,25 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
-\par \hich\af2\dbch\af31505\loch\f2         +.PARAMETER Log
-\par \hich\af2\dbch\af31505\loch\f2         Generates a log file for troubleshooting.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
+\par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output re\hich\af2\dbch\af31505\loch\f2 port.
+\par \hich\af2\dbch\af31505\loch\f2         +.PARAMETER Log
+\par \hich\af2\dbch\af31505\loch\f2         Generates a log file for troubleshooting.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard \hich\af2\dbch\af31505\loch\f2 characters?  false
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                \hich\af2\dbch\af31505\loch\f2     false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -387,61 +385,61 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
-\par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
+\par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is \hich\af2\dbch\af31505\loch\f2 run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?         \hich\af2\dbch\af31505\loch\f2            false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?\hich\af2\dbch\af31505\loch\f2        false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ReportFooter [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Outputs a footer sec\hich\af2\dbch\af31505\loch\f2 tion at the end of the report.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs a footer section at the end of the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of RF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Report Footer
 \par \hich\af2\dbch\af31505\loch\f2                 Report information:
 \par \hich\af2\dbch\af31505\loch\f2                         Created with: <Script Name> - Release Date: <Script Release Date>
-\par \hich\af2\dbch\af31505\loch\f2                         Script v\hich\af2\dbch\af31505\loch\f2 ersion: <Script Version>
+\par \hich\af2\dbch\af31505\loch\f2                         Script version: <Script Version>
 \par \hich\af2\dbch\af31505\loch\f2                         Started on <Date Time in Local Format>
-\par \hich\af2\dbch\af31505\loch\f2                         Elapsed time: nn days, nn hours, nn minutes, nn.nn seconds
+\par \hich\af2\dbch\af31505\loch\f2                         Elapsed time: nn days\hich\af2\dbch\af31505\loch\f2 , nn hours, nn minutes, nn.nn seconds
 \par \hich\af2\dbch\af31505\loch\f2                         Ran from domain <Domain Name> by user <Username>
-\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2             Ran from the folder <Folder Name>
+\par \hich\af2\dbch\af31505\loch\f2                         Ran from the folder <Folder Name>
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Script Name and Script Release date are script-specific variables.
 \par \hich\af2\dbch\af31505\loch\f2         Script version is a script variable.
 \par \hich\af2\dbch\af31505\loch\f2         Start Date Time in Local Format is a script variable.
 \par \hich\af2\dbch\af31505\loch\f2         Elapsed time is a calculated value.
-\par \hich\af2\dbch\af31505\loch\f2         Domain Name is $env:USERDNSDOMAIN.
+\par \hich\af2\dbch\af31505\loch\f2         Domain Name is $env:US\hich\af2\dbch\af31505\loch\f2 ERDNSDOMAIN.
 \par \hich\af2\dbch\af31505\loch\f2         Username is $env:USERNAME.
 \par \hich\af2\dbch\af31505\loch\f2         Folder Name is a script variable.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?            \hich\af2\dbch\af31505\loch\f2         false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?      \hich\af2\dbch\af31505\loch\f2  false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -StartDate <DateTime>
-\par \hich\af2\dbch\af31505\loch\f2         Start date for the Audit Trail repo\hich\af2\dbch\af31505\loch\f2 rt.
+\par \hich\af2\dbch\af31505\loch\f2         Start date for the Audit Trail report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Format for date only is MM/DD/YYYY.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24-hour format.
+\par \hich\af2\dbch\af31505\loch\f2         Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24-hour fo\hich\af2\dbch\af31505\loch\f2 rmat.
 \par \hich\af2\dbch\af31505\loch\f2         The double quotes are needed.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Default is today's date minus seven days.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter ha\hich\af2\dbch\af31505\loch\f2 s an alias of SD.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SD.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                ((Get-Date -displayhint date).AddDays(-7))
+\par \hich\af2\dbch\af31505\loch\f2         Default value          \hich\af2\dbch\af31505\loch\f2       ((Get-Date -displayhint date).AddDays(-7))
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard char\hich\af2\dbch\af31505\loch\f2 acters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -EndDate <DateTime>
 \par \hich\af2\dbch\af31505\loch\f2         End date for the Audit Trail report.
@@ -454,20 +452,20 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par \hich\af2\dbch\af31505\loch\f2         Default is today's date.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ED.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                (Get-Date -displayhint date)
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardw\hich\af2\dbch\af31505\loch\f2 are information on: Computer System, Disks, Processor and
+\par \hich\af2\dbch\af31505\loch\f2     -Hardware [<Swit\hich\af2\dbch\af31505\loch\f2 chParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on: Computer System, Disks, Processor and
 \par \hich\af2\dbch\af31505\loch\f2         Network Interface Cards
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of HW.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?               \hich\af2\dbch\af31505\loch\f2      named
+\par \hich\af2\dbch\af31505\loch\f2         Required?             \hich\af2\dbch\af31505\loch\f2        false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -504,30 +502,30 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard\hich\af2\dbch\af31505\loch\f2  characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
-\par \hich\af2\dbch\af31505\loch\f2         Com\hich\af2\dbch\af31505\loch\f2 pany Address to use for the Cover }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2 Page if}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2  the Cover Page has the Address field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2 Page if}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
+\hich\af2\dbch\af31505\loch\f2  the Cover Page has the Address field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 C\hich\af2\dbch\af31505\loch\f2 ontrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2              Filigree (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Wor\hich\af2\dbch\af31505\loch\f2 d 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                   \hich\af2\dbch\af31505\loch\f2  named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input? \hich\af2\dbch\af31505\loch\f2       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
@@ -537,7 +535,7 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output para\hich\af2\dbch\af31505\loch\f2 meters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -546,15 +544,15 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Comp\hich\af2\dbch\af31505\loch\f2 anyFax <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2 Page if}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
-\hich\af2\dbch\af31505\loch\f2  the Cover Page has the Fax field.
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the \hich\af2\dbch\af31505\loch\f2 Cover }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2 Page if}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2  the Cover Page has the Fax field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is on\hich\af2\dbch\af31505\loch\f2 ly valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -581,7 +579,7 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2 Page if}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
 \hich\af2\dbch\af31505\loch\f2  the Cover Page has the Phone field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone fie\hich\af2\dbch\af31505\loch\f2 ld:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone fiel\hich\af2\dbch\af31505\loch\f2 d:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
@@ -589,63 +587,63 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         P\hich\af2\dbch\af31505\loch\f2 osition?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
 \par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
-\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
+\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and \hich\af2\dbch\af31505\loch\f2 2016 are supported.
 \par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't \hich\af2\dbch\af31505\loch\f2 work well for this report)
+\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
+\par \hich\af2\dbch\af31505\loch\f2           \hich\af2\dbch\af31505\loch\f2       Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
 \par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
-\par \hich\af2\dbch\af31505\loch\f2                 afte\hich\af2\dbch\af31505\loch\f2 r title box is moved up)
+\par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2         Conservative (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if yo\hich\af2\dbch\af31505\loch\f2 u like looking sideways)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2          \hich\af2\dbch\af31505\loch\f2        Filigree (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (W\hich\af2\dbch\af31505\loch\f2 ord 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 manually re\hich\af2\dbch\af31505\loch\f2 sized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point\hich\af2\dbch\af31505\loch\f2 )
+\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
 \par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Pinstripes\hich\af2\dbch\af31505\loch\f2  (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
-\par \hich\af2\dbch\af31505\loch\f2           \hich\af2\dbch\af31505\loch\f2       resized or font changed to 14 point)
+\par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2             Slice (Dark) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Wor\hich\af2\dbch\af31505\loch\f2 d 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Tr\hich\af2\dbch\af31505\loch\f2 anscend (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
+\par \hich\af2\dbch\af31505\loch\f2         The default\hich\af2\dbch\af31505\loch\f2  value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSW\hich\af2\dbch\af31505\loch\f2 ORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
+\par \hich\af2\dbch\af31505\loch\f2         Default value     \hich\af2\dbch\af31505\loch\f2            Sideline
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -655,20 +653,20 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    \hich\af2\dbch\af31505\loch\f2 named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Specifies the optional email server to send the output report.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Require\hich\af2\dbch\af31505\loch\f2 d?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fals\hich\af2\dbch\af31505\loch\f2 e
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
@@ -686,23 +684,23 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         De\hich\af2\dbch\af31505\loch\f2 fault value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Acc\hich\af2\dbch\af31505\loch\f2 ept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -From <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required paramete\hich\af2\dbch\af31505\loch\f2 r.
+\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    fal\hich\af2\dbch\af31505\loch\f2 se
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the T\hich\af2\dbch\af31505\loch\f2 o email address.
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
+\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is us\hich\af2\dbch\af31505\loch\f2 ed, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -713,32 +711,32 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
 \par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-\par \hich\af2\dbch\af31505\loch\f2         Ou\hich\af2\dbch\af31505\loch\f2 tBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK \hich\af2\dbch\af31505\loch\f2 
-"https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable.\hich\af2\dbch\af31505\loch\f2  For more information, see
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}}}
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 ).
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 https:/go.microsof
+\hich\af2\dbch\af31505\loch\f2 t.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None. You cannot pipe objects to this script.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
-\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this sc\hich\af2\dbch\af31505\loch\f2 ript. This script creates a Word or PDF document.
+\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script. This script creates a Word or PDF document.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: PVS_Inventory_V6.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 6.03
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 6.0}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13442966 \hich\af2\dbch\af31505\loch\f2 4}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: February 8, 2022
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13442966 \hich\af2\dbch\af31505\loch\f2 March 6, 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     P\hich\af2\dbch\af31505\loch\f2 S C:\\PSScript >.\\PVS_Inventory_V6.ps1
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report by default.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -751,7 +749,7 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -LimitTargetDevices 5
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report by default.
-\par \hich\af2\dbch\af31505\loch\f2     The Target Device section is limited to the first five target devices in each \hich\af2\dbch\af31505\loch\f2 Device
+\par \hich\af2\dbch\af31505\loch\f2     The Target Devic\hich\af2\dbch\af31505\loch\f2 e section is limited to the first five target devices in each Device
 \par \hich\af2\dbch\af31505\loch\f2     Collection.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
@@ -760,9 +758,9 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -PDF
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.p\hich\af2\dbch\af31505\loch\f2 s1 -PDF
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document\hich\af2\dbch\af31505\loch\f2  as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a PDF file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par \hich\af2\dbch\af31505\loch\f2     AdminAddress = LocalHost
@@ -777,10 +775,10 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -Text
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory\hich\af2\dbch\af31505\loch\f2 _V6.ps1 -Text
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Saves the document as a formatted text file.
-\par \hich\af2\dbch\af31505\loch\f2     The compute\hich\af2\dbch\af31505\loch\f2 r running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
@@ -789,8 +787,8 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -HTML
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Saves the document as an HTML file.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminA\hich\af2\dbch\af31505\loch\f2 ddress.
+\par \hich\af2\dbch\af31505\loch\f2     Saves t\hich\af2\dbch\af31505\loch\f2 he document as an HTML file.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
@@ -859,8 +857,8 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 10 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V6.ps1 -CN "Carl Webster Consulting" -CP "Mod"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14427774\charrsid14427774 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\\hich\af2\dbch\af31505\loch\f2 PVS_Inventory_V6.ps1 -CN "Carl Webster Consulting" -CP "Mod"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
 \par \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster" -AdminAddress PVS1 -User cwebster
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
@@ -868,22 +866,22 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par \hich\af2\dbch\af31505\loch\f2     Prompts for the password for the cwebster account.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Carl Webster Consulting for the Company Name (alias CN).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting \hich\af2\dbch\af31505\loch\f2 for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
 \par \hich\af2\dbch\af31505\loch\f2         PVS1 for AdminAddress.
 \par \hich\af2\dbch\af31505\loch\f2         cwebster for User.
-\par \hich\af2\dbch\af31505\loch\f2         Script will prompt for the D\hich\af2\dbch\af31505\loch\f2 omain and Password
+\par \hich\af2\dbch\af31505\loch\f2         Script will prompt for the Domain and Password
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 11 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -\hich\af2\dbch\af31505\loch\f2 ------------------------- EXAMPLE 11 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V6.ps1 -CompanyName "Sherlock Holmes Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid14427774\charrsid14427774 
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Exposure -UserName "Dr. Watson" -CompanyAddress "221B Ba\hich\af2\dbch\af31505\loch\f2 ker Street, London,
-\par \hich\af2\dbch\af31505\loch\f2     England" -CompanyFax "+44 1753 276600" -CompanyPhone "+44 1753 276200"
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Exposure -UserName "Dr. Watson" -CompanyAddress "221B Baker Street, London,
+\par \hich\af2\dbch\af31505\loch\f2     Engl\hich\af2\dbch\af31505\loch\f2 and" -CompanyFax "+44 1753 276600" -CompanyPhone "+44 1753 276200"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
@@ -892,23 +890,23 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     +44 1753 276200 for the Company Phone.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Company Phone.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ------\hich\af2\dbch\af31505\loch\f2 -------------------- EXAMPLE 12 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V6.ps1 -CompanyName "Sherlock Holmes Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid14427774\charrsid14427774 
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet -UserName "Dr. Watson" -Co\hich\af2\dbch\af31505\loch\f2 mpanyEmail SuperSleuth@SherlockHolmes.com
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet -UserName "Dr. Watson" -CompanyEmail SuperSleuth@SherlockHolmes.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHo\hich\af2\dbch\af31505\loch\f2 lmes.com for the Company Email.
+\par \hich\af2\dbch\af31505\loch\f2         Dr. Watson fo\hich\af2\dbch\af31505\loch\f2 r the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Company Email.
 \par 
 \par 
 \par 
@@ -917,13 +915,13 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -StartDate "01/01/2021" -EndDate "01/31/2021"
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:user\hich\af2\dbch\af31505\loch\f2 name = Administrator
 \par \hich\af2\dbch\af31505\loch\f2     AdminAddress = LocalHost
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML document.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Returns all Audit Trail entries from "01/01/2021" through "01/31/2021".
+\par \hich\af2\dbch\af31505\loch\f2     Returns all Audit Trail entries from "01/01/2021" through "01/31/2021".
 \par 
 \par 
 \par 
@@ -932,7 +930,7 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -StartDate "01/01/2021 10:00:00" -EndDate}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid14427774\charrsid14427774 
-\par \hich\af2\dbch\af31505\loch\f2     "01/31/2021 14:00:0\hich\af2\dbch\af31505\loch\f2 0"
+\par \hich\af2\dbch\af31505\loch\f2     "01/31/2021 14:0\hich\af2\dbch\af31505\loch\f2 0:00"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par \hich\af2\dbch\af31505\loch\f2     AdminAddress = LocalHost
@@ -941,7 +939,7 @@ TargetDevices <Int32>] [-MSWord] [-PDF] [-CompanyAddress <String>] }{\rtlch\fcs1
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
 \par \hich\af2\dbch\af31505\loch\f2     Returns all Audit Trail entries from 01/01/2021 10:00 AM through 01/31/2021 2:00
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 PM.
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    PM.
 \par 
 \par 
 \par 
@@ -981,18 +979,18 @@ DocScriptTranscript_yyyyMMddTHHmmssffff.txt.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -SmtpServer mail.domain.tld -From}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14427774\charrsid14427774 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\\hich\af2\dbch\af31505\loch\f2 PSScript >.\\PVS_Inventory_V6.ps1 -SmtpServer mail.domain.tld -From}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
 \par \hich\af2\dbch\af31505\loch\f2     XDAdmin@domain.tld -To ITGroup@domain.tld
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mail.domain.tld, sending\hich\af2\dbch\af31505\loch\f2  from XDAdmin@domain.tld and
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mail.domain.tld, sending from XDAdmin@domain.tld and
 \par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and does not use SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The script \hich\af2\dbch\af31505\loch\f2 uses the default SMTP port 25 and does not use SSL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to \hich\af2\dbch\af31505\loch\f2 send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 email, the script prompts
-\par \hich\af2\dbch\af31505\loch\f2     the user to enter valid creden\hich\af2\dbch\af31505\loch\f2 tials.
+\par \hich\af2\dbch\af31505\loch\f2     the user to enter valid credentials.
 \par 
 \par 
 \par 
@@ -1006,51 +1004,50 @@ DocScriptTranscript_yyyyMMddTHHmmssffff.txt.
 \par \hich\af2\dbch\af31505\loch\f2     ***SENDING UNAUTHENTICATED EMAIL***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mailrelay.domain.tld, sending from
-\par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld and sending to ITGroup@domain.tld.
+\par \hich\af2\dbch\af31505\loch\f2     anonym\hich\af2\dbch\af31505\loch\f2 ous@domain.tld and sending to ITGroup@domain.tld.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send an unauthenticated email using an email relay server requires the From email
-\par \hich\af2\dbch\af31505\loch\f2     account to use the name Anonym\hich\af2\dbch\af31505\loch\f2 ous.
+\par \hich\af2\dbch\af31505\loch\f2     account to use the name Anonymous.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and does not use SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/2956491?hl=en"
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6767713 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid14427774\charrsid6767713 \hich\af2\dbch\af31505\loch\f2 
-https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/176600?hl=en"
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 {\*\datafield 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00032b00}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid14427774\charrsid6767713 \hich\af2\dbch\af31505\loch\f2 https://support.google.com/a/answ
+\hich\af2\dbch\af31505\loch\f2 er/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6767713 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid14427774\charrsid6767713 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid14427774\charrsid6767713 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g\hich\af2\dbch\af31505\loch\f2 -suite account, you may have to turn ON the "Less
+\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to turn ON the "Less
 \par \hich\af2\dbch\af31505\loch\f2     secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script generates an anonymous, secure password for the anonymous@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     The script generates an anonymous, secure password for the anonymous@domain.t\hich\af2\dbch\af31505\loch\f2 ld
 \par \hich\af2\dbch\af31505\loch\f2     account.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ------------------\hich\af2\dbch\af31505\loch\f2 -------- EXAMPLE 19 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 19 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -SmtpServer}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid14427774\charrsid14427774 
 \par \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protection.outlook.com -UseSSL -From
-\par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
+\par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroup\hich\af2\dbch\af31505\loch\f2 DL@labaddomain.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
-HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 
-{\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2 
+ HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid14427774\charrsid6767713 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3
-}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid14427774\charrsid6767713 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-u\hich\af2\dbch\af31505\loch\f2 
+p-a-multifunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
 \par 
@@ -1064,14 +1061,14 @@ HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/ho
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -----------------\hich\af2\dbch\af31505\loch\f2 --------- EXAMPLE 20 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 20 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -SmtpServer smtp.office365.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14427774\charrsid14427774 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 \hich\af2\dbch\af31505\loch\f2 -SmtpServer smtp.office365.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.offic\hich\af2\dbch\af31505\loch\f2 e365.com on port 587 using SSL, sending from
-\par \hich\af2\dbch\af31505\loch\f2     webster@carlwebster.com and sending to ITGroup@carlwebster.com.
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.office365.com on port 587 using SSL, sending from
+\par \hich\af2\dbch\af31505\loch\f2     webster@carlwebster.com and sending to ITGr\hich\af2\dbch\af31505\loch\f2 oup@carlwebster.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email, the script prompts
 \par \hich\af2\dbch\af31505\loch\f2     the user to enter valid credentials.
@@ -1081,19 +1078,19 @@ HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/ho
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 21 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14427774\charrsid14427774 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inve\hich\af2\dbch\af31505\loch\f2 ntory_V6.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
-\par \hich\af2\dbch\af31505\loch\f2     To send a\hich\af2\dbch\af31505\loch\f2 n email using a Gmail or g-suite account, you may have to turn ON the "Less
-\par \hich\af2\dbch\af31505\loch\f2     secure app access" option on your account.
+\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to turn ON the "Less
+\par \hich\af2\dbch\af31505\loch\f2     secure app access" o\hich\af2\dbch\af31505\loch\f2 ption on your account.
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.gmail.com on port 587 using SSL, sending from
-\par \hich\af2\dbch\af31505\loch\f2     webster@gmail.com and s\hich\af2\dbch\af31505\loch\f2 ending to ITGroup@carlwebster.com.
+\par \hich\af2\dbch\af31505\loch\f2     webster@gmail.com and sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to \hich\af2\dbch\af31505\loch\f2 send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 email, the script prompts
 \par \hich\af2\dbch\af31505\loch\f2     the user to enter valid credentials.
 \par 
@@ -1218,8 +1215,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000f0da
-27353b1dd801feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000f028
+b72c5231d801feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/PVS_V6_Script_ChangeLog.txt
+++ b/PVS_V6_Script_ChangeLog.txt
@@ -8,6 +8,21 @@
 #Version 6.00 is based on 5.21
 #
 
+#Version 6.04 6-Mar-2022
+#	Add Function Get-IPAddress
+#	Fixed bug when retrieving a Device Collection's Administrators and Operators
+#		I was not comparing to the specific device collection name, which returned all administrators and 
+#		operators for all device collections and not the device collection being processed 
+#	Format the Farm, Properties, Status section to match the console output
+#	In Function OutputFarm, add the following:
+#		License server IP address
+#		For the Options tab info, section headings to Word/PDF and HTML output that were in the Text output
+#		SQL Server IP address
+#		Failover partner IP address
+#		MultiSubnetFailover to Farm Status section
+#			Thanks to Arnaud Pain
+#			I can't believe no one has asked for this since PVS 7.11 was released on 14-Sep-2016
+
 #Version 6.03 8-Feb-2022
 #	Changed the date format for the transcript and error log files from yyyy-MM-dd_HHmm format to the FileDateTime format
 #		The format is yyyyMMddTHHmmssffff (case-sensitive, using a 4-digit year, 2-digit month, 2-digit day, 


### PR DESCRIPTION
#Version 6.04 6-Mar-2022
#	Add Function Get-IPAddress
#	Fixed bug when retrieving a Device Collection's Administrators and Operators
#		I was not comparing to the specific device collection name, which returned all administrators and 
#		operators for all device collections and not the device collection being processed 
#	Format the Farm, Properties, Status section to match the console output
#	In Function OutputFarm, add the following:
#		License server IP address
#		For the Options tab info, section headings to Word/PDF and HTML output that were in the Text output
#		SQL Server IP address
#		Failover partner IP address
#		MultiSubnetFailover to Farm Status section
#			Thanks to Arnaud Pain
#			I can't believe no one has asked for this since PVS 7.11 was released on 14-Sep-2016