### PR TITLE
Final update for 6.07

### DIFF
--- a/PVS_Inventory_V6.ps1
+++ b/PVS_Inventory_V6.ps1
@@ -488,9 +488,9 @@
 	No objects are output from this script. This script creates a Word or PDF document.
 .NOTES
 	NAME: PVS_Inventory_V6.ps1
-	VERSION: 6.06
+	VERSION: 6.07
 	AUTHOR: Carl Webster
-	LASTEDIT: April 25, 2022
+	LASTEDIT: April 17, 2023
 #>
 
 #endregion
@@ -620,6 +620,34 @@ Param(
 #Created on December 21, 2020
 
 #Version 6.00 is based on 5.21
+#
+#Version 6.07
+#	Added new Farm properties introduced in 2303, SetupType and CloudSetupActive
+#		If(SetupType -eq 1 -and CloudSetupActive -eq $True )
+#		{
+#			"Farm is in cloud setup and all PVS servers have updated to cloud mode"
+#		}
+#		ElseIf(SetupType -eq 1 -and CloudSetupActive -eq $False )
+#		{
+#			"Farm is in cloud setup and all PVS servers have not updated to cloud mode"
+#		}
+#		ElseIf(SetupType -eq 0)
+#		{
+#			"Farm is in on-premises mode"
+#		}
+#	For Text output, fixed some formatting and alignment issues
+#	In Function OutputSite:
+#		If SetupType is 1 (Cloud), output the Cloud Customer ID and Name in the Licensing section
+#		Added two new Virtual Hosting Pool connection types added in 2303:
+#			4 = Azure
+#			5 = Google Cloud Platform
+#		Notes:
+#			You must run the PVS server and console in Azure to see Azure-specific options.
+#			You must run the PVS server and console in GCP to see GCP-specific options.
+#			You cannot stream to Azure or GCP from On-premises, for example.
+#			Citrix only supports creating PVS targets in Azure or GCP as part of streaming CVAD catalog VDAs. 
+#			Citrix only supports creating virtual hosting pool records for Azure and GCP from a CVAD 
+#				Hosting unit as part of the CVAD Setup Wizard.
 #
 #Version 6.06 25-Apr-2022
 #	Change all Get-WMIObject to Get-CIMInstance
@@ -810,9 +838,9 @@ Set-StrictMode -Version Latest
 $PSDefaultParameterValues = @{"*:Verbose"=$True}
 $SaveEAPreference         = $ErrorActionPreference
 $ErrorActionPreference    = 'SilentlyContinue'
-$script:MyVersion         = '6.06'
+$script:MyVersion         = '6.07'
 $Script:ScriptName        = "PVS_Inventory_V6.ps1"
-$tmpdate                  = [datetime] "04/25/2022"
+$tmpdate                  = [datetime] "04/17/2023"
 $Script:ReleaseDate       = $tmpdate.ToUniversalTime().ToShortDateString()
 
 If($Null -eq $HTML)
@@ -1639,15 +1667,15 @@ Function OutputComputerItem
 	}
 	If($Text)
 	{
-		Line 2 "Manufacturer`t`t`t: " $Item.manufacturer
-		Line 2 "Model`t`t`t`t: " $Item.model
-		Line 2 "Domain`t`t`t`t: " $Item.domain
-		Line 2 "Operating System`t`t: " $OS
-		Line 2 "Power Plan`t`t`t: " $PowerPlan
-		Line 2 "Total Ram`t`t`t: $($Item.totalphysicalram) GB"
-		Line 2 "Physical Processors (sockets)`t: " $Item.NumberOfProcessors
-		Line 2 "Logical Processors (cores w/HT)`t: " $Item.NumberOfLogicalProcessors
-		Line 2 ""
+		Line 5 "Manufacturer`t`t`t: " $Item.manufacturer
+		Line 5 "Model`t`t`t`t: " $Item.model
+		Line 5 "Domain`t`t`t`t: " $Item.domain
+		Line 5 "Operating System`t`t: " $OS
+		Line 5 "Power Plan`t`t`t: " $PowerPlan
+		Line 5 "Total Ram`t`t`t: $($Item.totalphysicalram) GB"
+		Line 5 "Physical Processors (sockets)`t: " $Item.NumberOfProcessors
+		Line 5 "Logical Processors (cores w/HT)`t: " $Item.NumberOfLogicalProcessors
+		Line 5 ""
 	}
 	If($HTML)
 	{
@@ -1743,27 +1771,27 @@ Function OutputDriveItem
 	}
 	If($Text)
 	{
-		Line 2 "Caption`t`t: " $drive.caption
-		Line 2 "Size`t`t: $($drive.drivesize) GB"
+		Line 5 "Caption`t`t: " $drive.caption
+		Line 5 "Size`t`t: $($drive.drivesize) GB"
 		If(![String]::IsNullOrEmpty($drive.filesystem))
 		{
-			Line 2 "File System`t: " $drive.filesystem
+			Line 5 "File System`t: " $drive.filesystem
 		}
-		Line 2 "Free Space`t: $($drive.drivefreespace) GB"
+		Line 5 "Free Space`t: $($drive.drivefreespace) GB"
 		If(![String]::IsNullOrEmpty($drive.volumename))
 		{
-			Line 2 "Volume Name`t: " $drive.volumename
+			Line 5 "Volume Name`t: " $drive.volumename
 		}
 		If(![String]::IsNullOrEmpty($drive.volumedirty))
 		{
-			Line 2 "Volume is Dirty`t: " $xVolumeDirty
+			Line 5 "Volume is Dirty`t: " $xVolumeDirty
 		}
 		If(![String]::IsNullOrEmpty($drive.volumeserialnumber))
 		{
-			Line 2 "Volume Serial #`t: " $drive.volumeserialnumber
+			Line 5 "Volume Serial #`t: " $drive.volumeserialnumber
 		}
-		Line 2 "Drive Type`t: " $xDriveType
-		Line 2 ""
+		Line 5 "Drive Type`t: " $xDriveType
+		Line 5 ""
 	}
 	If($HTML)
 	{
@@ -1868,27 +1896,27 @@ Function OutputProcessorItem
 	}
 	If($Text)
 	{
-		Line 2 "Name`t`t`t`t: " $processor.name
-		Line 2 "Description`t`t`t: " $processor.description
-		Line 2 "Max Clock Speed`t`t`t: $($processor.maxclockspeed) MHz"
+		Line 5 "Name`t`t`t`t: " $processor.name
+		Line 5 "Description`t`t`t: " $processor.description
+		Line 5 "Max Clock Speed`t`t`t: $($processor.maxclockspeed) MHz"
 		If($processor.l2cachesize -gt 0)
 		{
-			Line 2 "L2 Cache Size`t`t`t: $($processor.l2cachesize) KB"
+			Line 5 "L2 Cache Size`t`t`t: $($processor.l2cachesize) KB"
 		}
 		If($processor.l3cachesize -gt 0)
 		{
-			Line 2 "L3 Cache Size`t`t`t: $($processor.l3cachesize) KB"
+			Line 5 "L3 Cache Size`t`t`t: $($processor.l3cachesize) KB"
 		}
 		If($processor.numberofcores -gt 0)
 		{
-			Line 2 "# of Cores`t`t`t: " $processor.numberofcores
+			Line 5 "# of Cores`t`t`t: " $processor.numberofcores
 		}
 		If($processor.numberoflogicalprocessors -gt 0)
 		{
-			Line 2 "# of Logical Procs (cores w/HT)`t: " $processor.numberoflogicalprocessors
+			Line 5 "# of Logical Procs (cores w/HT)`t: " $processor.numberoflogicalprocessors
 		}
-		Line 2 "Availability`t`t`t: " $xAvailability
-		Line 2 ""
+		Line 5 "Availability`t`t`t: " $xAvailability
+		Line 5 ""
 	}
 	If($HTML)
 	{
@@ -2200,104 +2228,104 @@ Function OutputNicItem
 	}
 	If($Text)
 	{
-		Line 2 "Name`t`t`t: " $ThisNic.Name
+		Line 5 "Name`t`t`t: " $ThisNic.Name
 		If($ThisNic.Name -ne $nic.description)
 		{
-			Line 2 "Description`t`t: " $nic.description
+			Line 5 "Description`t`t: " $nic.description
 		}
-		Line 2 "Connection ID`t`t: " $ThisNic.NetConnectionID
+		Line 5 "Connection ID`t`t: " $ThisNic.NetConnectionID
 		If(validObject $Nic Manufacturer)
 		{
-			Line 2 "Manufacturer`t`t: " $Nic.manufacturer
+			Line 5 "Manufacturer`t`t: " $Nic.manufacturer
 		}
-		Line 2 "Availability`t`t: " $xAvailability
-		Line 2 "Allow computer to turn "
-		Line 2 "off device to save power: " $PowerSaving
-		Line 2 "Physical Address`t: " $nic.macaddress
-		Line 2 "Receive Side Scaling`t: " $RSSEnabled
-		Line 2 "IP Address`t`t: " $xIPAddress[0]
+		Line 5 "Availability`t`t: " $xAvailability
+		Line 5 "Allow computer to turn "
+		Line 5 "off device to save power: " $PowerSaving
+		Line 5 "Physical Address`t: " $nic.macaddress
+		Line 5 "Receive Side Scaling`t: " $RSSEnabled
+		Line 5 "IP Address`t`t: " $xIPAddress[0]
 		$cnt = -1
 		ForEach($tmp in $xIPAddress)
 		{
 			$cnt++
 			If($cnt -gt 0)
 			{
-				Line 8 "  " $tmp
+				Line 11 "  " $tmp
 			}
 		}
-		Line 2 "Default Gateway`t`t: " $Nic.Defaultipgateway
-		Line 2 "Subnet Mask`t`t: " $xIPSubnet[0]
+		Line 5 "Default Gateway`t`t: " $Nic.Defaultipgateway
+		Line 5 "Subnet Mask`t`t: " $xIPSubnet[0]
 		$cnt = -1
 		ForEach($tmp in $xIPSubnet)
 		{
 			$cnt++
 			If($cnt -gt 0)
 			{
-				Line 8 "  " $tmp
+				Line 11 "  " $tmp
 			}
 		}
 		If($nic.dhcpenabled)
 		{
-			Line 2 "DHCP Enabled`t`t: " $nic.dhcpenabled.ToString()
-			Line 2 "DHCP Lease Obtained`t: " $dhcpleaseobtaineddate
-			Line 2 "DHCP Lease Expires`t: " $dhcpleaseexpiresdate
-			Line 2 "DHCP Server`t`t:" $nic.dhcpserver
+			Line 5 "DHCP Enabled`t`t: " $nic.dhcpenabled.ToString()
+			Line 5 "DHCP Lease Obtained`t: " $dhcpleaseobtaineddate
+			Line 5 "DHCP Lease Expires`t: " $dhcpleaseexpiresdate
+			Line 5 "DHCP Server`t`t:" $nic.dhcpserver
 		}
 		Else
 		{
-			Line 2 "DHCP Enabled`t`t: " $nic.dhcpenabled.ToString()
+			Line 5 "DHCP Enabled`t`t: " $nic.dhcpenabled.ToString()
 		}
 		If(![String]::IsNullOrEmpty($nic.dnsdomain))
 		{
-			Line 2 "DNS Domain`t`t: " $nic.dnsdomain
+			Line 5 "DNS Domain`t`t: " $nic.dnsdomain
 		}
 		If($Null -ne $nic.dnsdomainsuffixsearchorder -and $nic.dnsdomainsuffixsearchorder.length -gt 0)
 		{
 			[int]$x = 1
-			Line 2 "DNS Search Suffixes`t: " $xnicdnsdomainsuffixsearchorder[0]
+			Line 5 "DNS Search Suffixes`t: " $xnicdnsdomainsuffixsearchorder[0]
 			$cnt = -1
 			ForEach($tmp in $xnicdnsdomainsuffixsearchorder)
 			{
 				$cnt++
 				If($cnt -gt 0)
 				{
-					Line 8 "  " $tmp
+					Line 11 "  " $tmp
 				}
 			}
 		}
-		Line 2 "DNS WINS Enabled`t: " $xdnsenabledforwinsresolution
+		Line 5 "DNS WINS Enabled`t: " $xdnsenabledforwinsresolution
 		If($Null -ne $nic.dnsserversearchorder -and $nic.dnsserversearchorder.length -gt 0)
 		{
 			[int]$x = 1
-			Line 2 "DNS Servers`t`t: " $xnicdnsserversearchorder[0]
+			Line 5 "DNS Servers`t`t: " $xnicdnsserversearchorder[0]
 			$cnt = -1
 			ForEach($tmp in $xnicdnsserversearchorder)
 			{
 				$cnt++
 				If($cnt -gt 0)
 				{
-					Line 8 "  " $tmp
+					Line 11 "  " $tmp
 				}
 			}
 		}
-		Line 2 "NetBIOS Setting`t`t: " $xTcpipNetbiosOptions
-		Line 2 "WINS:"
-		Line 3 "Enabled LMHosts`t: " $xwinsenablelmhostslookup
+		Line 5 "NetBIOS Setting`t`t: " $xTcpipNetbiosOptions
+		Line 5 "WINS:"
+		Line 6 "Enabled LMHosts`t: " $xwinsenablelmhostslookup
 		If(![String]::IsNullOrEmpty($nic.winshostlookupfile))
 		{
-			Line 3 "Host Lookup File`t: " $nic.winshostlookupfile
+			Line 6 "Host Lookup File`t: " $nic.winshostlookupfile
 		}
 		If(![String]::IsNullOrEmpty($nic.winsprimaryserver))
 		{
-			Line 3 "Primary Server`t: " $nic.winsprimaryserver
+			Line 6 "Primary Server`t: " $nic.winsprimaryserver
 		}
 		If(![String]::IsNullOrEmpty($nic.winssecondaryserver))
 		{
-			Line 3 "Secondary Server`t: " $nic.winssecondaryserver
+			Line 6 "Secondary Server`t: " $nic.winssecondaryserver
 		}
 		If(![String]::IsNullOrEmpty($nic.winsscopeid))
 		{
-			Line 3 "Scope ID`t`t: " $nic.winsscopeid
+			Line 6 "Scope ID`t`t: " $nic.winsscopeid
 		}
 		Line 0 ""
 	}
@@ -6279,12 +6307,43 @@ Function OutputFarm
 				$ScriptInformation += @{ Data = "     On-Premises"; Value = "Yes"; }
 				$ScriptInformation += @{ Data = "          Use Datacenter licenses for desktops if no Desktop licenses are available"; Value = $DatacenterLicense; }
 				$ScriptInformation += @{ Data = "     Cloud"; Value = "No"; }
+				If(validObject $farm CloudSetupActive) #added in PVS 2303
+				{
+					<#
+						SetupType: Either on-premise or cloud. 0 for on-premise mode, 1 for cloud mode. Min=0, Max=1, Default=0
+						
+						CloudSetupActive: True if farm is in cloud setup and all PVS servers have also been updated to cloud mode.
+						Default=false
+					#>
+					$ScriptInformation += @{ Data = "     Farm is in on-premises mode"; Value = ""; }
+				}
 			}
 			ElseIf($farm.LicenseSKU -eq 1)
 			{
 				$ScriptInformation += @{ Data = "     On-Premises"; Value = "No"; }
 				$ScriptInformation += @{ Data = "          Use Datacenter licenses for desktops if no Desktop licenses are available"; Value = $DatacenterLicense; }
 				$ScriptInformation += @{ Data = "     Cloud"; Value = "Yes"; }
+				If(validObject $farm CloudSetupActive) #added in PVS 2303
+				{
+					<#
+						SetupType: Either on-premise or cloud. 0 for on-premise mode, 1 for cloud mode. Min=0, Max=1, Default=0
+						
+						CloudSetupActive: True if farm is in cloud setup and all PVS servers have also been updated to cloud mode.
+						Default=false
+					#>
+					If($farm.SetupType -eq 1 -and $farm.CloudSetupActive -eq $True )
+					{
+						$ScriptInformation += @{ Data = "     Cloud Customer ID"; Value = $farm.CustomerId; }
+						$ScriptInformation += @{ Data = "     Cloud Customer Name"; Value = $farm.CustomerName; }
+						$ScriptInformation += @{ Data = "     Farm is in cloud setup and all PVS servers have updated to cloud mode"; Value = ""; }
+					}
+					ElseIf($farm.SetupType -eq 1 -and $farm.CloudSetupActive -eq $False )
+					{
+						$ScriptInformation += @{ Data = "     Cloud Customer ID"; Value = $farm.CustomerId; }
+						$ScriptInformation += @{ Data = "     Cloud Customer Name"; Value = $farm.CustomerName; }
+						$ScriptInformation += @{ Data = "     Farm is in cloud setup and all PVS servers have not updated to cloud mode"; Value = ""; }
+					}
+				}
 			}
 			Else
 			{
@@ -6295,6 +6354,7 @@ Function OutputFarm
 		{
 			$ScriptInformation += @{ Data = "Use Datacenter licenses for desktops if no Desktop licenses are available"; Value = $DatacenterLicense; }
 		}
+
 		$Table = AddWordTable -Hashtable $ScriptInformation `
 		-Columns Data,Value `
 		-List `
@@ -6323,12 +6383,43 @@ Function OutputFarm
 				Line 2 "On-Premises`t: " "Yes"
 				Line 3 "Use Datacenter licenses for desktops if no Desktop licenses are available: " $DatacenterLicense
 				Line 2 "Cloud`t`t: " "No"
+				If(validObject $farm CloudSetupActive) #added in PVS 2303
+				{
+					<#
+						SetupType: Either on-premise or cloud. 0 for on-premise mode, 1 for cloud mode. Min=0, Max=1, Default=0
+						
+						CloudSetupActive: True if farm is in cloud setup and all PVS servers have also been updated to cloud mode.
+						Default=false
+					#>
+					Line 3 "Farm is in on-premises mode"
+				}
 			}
 			ElseIf($farm.LicenseSKU -eq 1)
 			{
 				Line 2 "On-Premises`t: " "No"
 				Line 3 "Use Datacenter licenses for desktops if no Desktop licenses are available: " $DatacenterLicense
 				Line 2 "Cloud`t`t: " "Yes"
+				If(validObject $farm CloudSetupActive) #added in PVS 2303
+				{
+					<#
+						SetupType: Either on-premise or cloud. 0 for on-premise mode, 1 for cloud mode. Min=0, Max=1, Default=0
+						
+						CloudSetupActive: True if farm is in cloud setup and all PVS servers have also been updated to cloud mode.
+						Default=false
+					#>
+					If($farm.SetupType -eq 1 -and $farm.CloudSetupActive -eq $True )
+					{
+						Line 3 "Cloud Customer ID`t: " $farm.CustomerId
+						Line 3 "Cloud Customer Name`t: " $farm.CustomerName
+						Line 3 "Farm is in cloud setup and all PVS servers have updated to cloud mode"
+					}
+					ElseIf($farm.SetupType -eq 1 -and $farm.CloudSetupActive -eq $False )
+					{
+						Line 3 "Cloud Customer ID`t: " $farm.CustomerId
+						Line 3 "Cloud Customer Name`t: " $farm.CustomerName
+						Line 3 "Farm is in cloud setup and all PVS servers have not updated to cloud mode"
+					}
+				}
 			}
 			Else
 			{
@@ -6356,12 +6447,43 @@ Function OutputFarm
 				$rowdata += @(,("     On-Premises",($htmlsilver -bor $htmlbold),"Yes",$htmlwhite))
 				$rowdata += @(,("          Use Datacenter licenses for desktops if no Desktop licenses are available",($htmlsilver -bor $htmlbold),$DatacenterLicense,$htmlwhite))
 				$rowdata += @(,("     Cloud",($htmlsilver -bor $htmlbold),"No",$htmlwhite))
+				If(validObject $farm CloudSetupActive) #added in PVS 2303
+				{
+					<#
+						SetupType: Either on-premise or cloud. 0 for on-premise mode, 1 for cloud mode. Min=0, Max=1, Default=0
+						
+						CloudSetupActive: True if farm is in cloud setup and all PVS servers have also been updated to cloud mode.
+						Default=false
+					#>
+					rowdata += @(,("     Farm is in on-premises mode",($htmlsilver -bor $htmlbold),"",$htmlwhite))
+				}
 			}
 			ElseIf($farm.LicenseSKU -eq 1)
 			{
 				$rowdata += @(,("     On-Premises",($htmlsilver -bor $htmlbold),"No",$htmlwhite))
 				$rowdata += @(,("          Use Datacenter licenses for desktops if no Desktop licenses are available",($htmlsilver -bor $htmlbold),$DatacenterLicense,$htmlwhite))
 				$rowdata += @(,("     Cloud",($htmlsilver -bor $htmlbold),"Yes",$htmlwhite))
+				If(validObject $farm CloudSetupActive) #added in PVS 2303
+				{
+					<#
+						SetupType: Either on-premise or cloud. 0 for on-premise mode, 1 for cloud mode. Min=0, Max=1, Default=0
+						
+						CloudSetupActive: True if farm is in cloud setup and all PVS servers have also been updated to cloud mode.
+						Default=false
+					#>
+					If($farm.SetupType -eq 1 -and $farm.CloudSetupActive -eq $True )
+					{
+						$rowdata += @(,("     Cloud Customer ID",($htmlsilver -bor $htmlbold),$farm.CustomerId,$htmlwhite))
+						$rowdata += @(,("     Cloud Customer Name",($htmlsilver -bor $htmlbold),$farm.CustomerName,$htmlwhite))
+						$rowdata += @(,("     Farm is in cloud setup and all PVS servers have updated to cloud mode",($htmlsilver -bor $htmlbold),"",$htmlwhite))
+					}
+					ElseIf($farm.SetupType -eq 1 -and $farm.CloudSetupActive -eq $False )
+					{
+						$rowdata += @(,("     Cloud Customer ID",($htmlsilver -bor $htmlbold),$farm.CustomerId,$htmlwhite))
+						$rowdata += @(,("     Cloud Customer Name",($htmlsilver -bor $htmlbold),$farm.CustomerName,$htmlwhite))
+						$rowdata += @(,("     Farm is in cloud setup and all PVS servers have not updated to cloud mode",($htmlsilver -bor $htmlbold),"",$htmlwhite))
+					}
+				}
 			}
 			Else
 			{
@@ -6550,7 +6672,7 @@ Function OutputFarm
 		$ScriptInformation += @{ Data = "Failover Partner Server"; Value = $farm.failoverPartnerServerName; }
 		$ScriptInformation += @{ Data = "Failover Partner Server IP"; Value = $FailoverSQLServerIPAddress; }
 		$ScriptInformation += @{ Data = "Failover Partner Instance"; Value = $farm.failoverPartnerServerName; }
-		$ScriptInformation += @{ Data = "MultiSubnetFailover"; Value = $MultiSubnetFailover; }
+		$ScriptInformation += @{ Data = "Multi-subnet Failover"; Value = $MultiSubnetFailover; }
 		$ScriptInformation += @{ Data = $xadGroupsEnabled; Value = ""; }
 		$Table = AddWordTable -Hashtable $ScriptInformation `
 		-Columns Data,Value `
@@ -6570,14 +6692,14 @@ Function OutputFarm
 	{
 		Line 0 "Status"
 		Line 1 "Current status of the farm:"
-		Line 2 "Database server`t: " $farm.databaseServerName
-		Line 2 "Database server IP`t: " $SQLServerIPAddress
-		Line 2 "Database instance`t: " $farm.databaseInstanceName
-		Line 2 "Database`t: " $farm.databaseName
-		Line 2 "Failover Partner Server: " $farm.failoverPartnerServerName
-		Line 2 "Failover Partner Server IP: " $FailoverSQLServerIPAddress
-		Line 2 "Failover Partner Instance: " $farm.failoverPartnerInstanceName
-		Line 2 "MultiSubnetFailover`t`t: " $MultiSubnetFailover
+		Line 2 "Database server`t`t`t: " $farm.databaseServerName
+		Line 2 "Database server IP`t`t: " $SQLServerIPAddress
+		Line 2 "Database instance`t`t: " $farm.databaseInstanceName
+		Line 2 "Database`t`t`t: " $farm.databaseName
+		Line 2 "Failover Partner Server`t`t: " $farm.failoverPartnerServerName
+		Line 2 "Failover Partner Server IP`t: " $FailoverSQLServerIPAddress
+		Line 2 "Failover Partner Instance`t: " $farm.failoverPartnerInstanceName
+		Line 2 "Multi-subnet Failover`t`t: " $MultiSubnetFailover
 		Line 2 "" $xadGroupsEnabled
 		Line 0 ""
 	}
@@ -6592,7 +6714,7 @@ Function OutputFarm
 		$rowdata += @(,('Failover Partner Server',($htmlsilver -bor $htmlbold),$farm.failoverPartnerServerName,$htmlwhite))
 		$rowdata += @(,('Failover Partner Server IP',($htmlsilver -bor $htmlbold),$FailoverSQLServerIPAddress,$htmlwhite))
 		$rowdata += @(,('Failover Partner Instance',($htmlsilver -bor $htmlbold),$farm.failoverPartnerInstanceName,$htmlwhite))
-		$rowdata += @(,('MultiSubnetFailover',($htmlsilver -bor $htmlbold),$MultiSubnetFailover,$htmlwhite))
+		$rowdata += @(,('Multi-subnet Failover',($htmlsilver -bor $htmlbold),$MultiSubnetFailover,$htmlwhite))
 		$rowdata += @(,('',($htmlsilver -bor $htmlbold),$xadGroupsEnabled,$htmlwhite))
 		
 		$msg = "Current status of the farm"
@@ -10149,6 +10271,8 @@ Function OutputSite
 				1 		{$vHostType = "Microsoft SCVMM/Hyper-V"; Break}
 				2 		{$vHostType = "VMWare vSphere/ESX"; Break}
 				3 		{$vHostType = "Nutanix"; Break}
+				4 		{$vHostType = "Azure"; Break} #added in 2303
+				5 		{$vHostType = "GCP"; Break} #added in 2303
 				Default {$vHostType = "Virtualization Host type could not be determined: $($vHost.type)"; Break}
 			}
 

--- a/PVS_Inventory_V6_ReadMe.rtf
+++ b/PVS_Inventory_V6_ReadMe.rtf
@@ -1,8 +1,8 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f47\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f48\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
@@ -126,15 +126,15 @@ Hyperlink;}{\*\cs19 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf20\chshdng0\chcfpa
 \leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
 \leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid2008631076}}{\*\listoverridetable{\listoverride\listid558714133\listoverridecount0\ls1}{\listoverride\listid676005662
 \listoverridecount0\ls2}{\listoverride\listid1940482595\listoverridecount0\ls3}{\listoverride\listid872425844\listoverridecount0\ls4}{\listoverride\listid2008631076\listoverridecount0\ls5}{\listoverride\listid314996233\listoverridecount0\ls6}
-{\listoverride\listid1217358328\listoverridecount0\ls7}{\listoverride\listid642077380\listoverridecount0\ls8}{\listoverride\listid100271447\listoverridecount0\ls9}}{\*\rsidtbl \rsid153717\rsid225946\rsid401028\rsid735408\rsid1919522\rsid2246377
-\rsid2307810\rsid2388634\rsid2584501\rsid2585069\rsid2902022\rsid3085909\rsid3154381\rsid3345712\rsid3478208\rsid3679694\rsid4090611\rsid4160880\rsid4482658\rsid5058413\rsid5185810\rsid5318453\rsid5405950\rsid5661568\rsid5715848\rsid5990872\rsid6241543
-\rsid6767713\rsid7282308\rsid7954372\rsid8018432\rsid8789310\rsid8942798\rsid8982599\rsid9249456\rsid9466969\rsid10386082\rsid11218240\rsid11558710\rsid12087820\rsid12126521\rsid12282547\rsid12988199\rsid13253201\rsid13265712\rsid13442966\rsid13762634
-\rsid14224466\rsid14316788\rsid14427774\rsid14694937\rsid14772334\rsid14894181\rsid15682948\rsid15800026\rsid16003468}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info
-{\operator Carl Webster}{\creatim\yr2014\mo4\dy1\hr13\min41}{\revtim\yr2022\mo4\dy25\hr6\min50}{\version46}{\edmins228}{\nofpages16}{\nofwords4491}{\nofchars25602}{\nofcharsws30033}{\vern45}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2
-003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+{\listoverride\listid1217358328\listoverridecount0\ls7}{\listoverride\listid642077380\listoverridecount0\ls8}{\listoverride\listid100271447\listoverridecount0\ls9}}{\*\rsidtbl \rsid153717\rsid225946\rsid401028\rsid735408\rsid1264448\rsid1919522
+\rsid2246377\rsid2307810\rsid2388634\rsid2584501\rsid2585069\rsid2902022\rsid3085909\rsid3154381\rsid3345712\rsid3478208\rsid3679694\rsid4090611\rsid4160880\rsid4482658\rsid5058413\rsid5185810\rsid5318453\rsid5405950\rsid5661568\rsid5715848\rsid5990872
+\rsid6241543\rsid6767713\rsid7282308\rsid7950751\rsid7954372\rsid8018432\rsid8789310\rsid8942798\rsid8982599\rsid9249456\rsid9466969\rsid10386082\rsid11218240\rsid11558710\rsid12087820\rsid12126521\rsid12282547\rsid12988199\rsid13253201\rsid13265712
+\rsid13442966\rsid13762634\rsid14224466\rsid14316788\rsid14427774\rsid14694937\rsid14772334\rsid14894181\rsid15682948\rsid15800026\rsid16003468}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440
+\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo4\dy1\hr13\min41}{\revtim\yr2023\mo4\dy17\hr12\min29}{\version48}{\edmins229}{\nofpages16}{\nofwords4068}{\nofchars25996}{\nofcharsws29180}{\vern69}}{\*\userprops {\propname GrammarlyDoc
+umentId}\proptype30{\staticval a835dd8533a7718185a38d3fdce5076c787e8daabb35dbd65524213cd781d135}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot14894181 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDYyNjI0NDM0tDA2MzYyNTVX0lEKTi0uzszPAymwrAUACDglaSwAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot14894181 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDYyNjI0NDM0tDA2MzYyNTVX0lEKTi0uzszPAykwNKgFAPYvwLktAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -291,7 +291,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Domain <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the domain used for the AdminAddress connection.
@@ -302,7 +302,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:UserD\hich\af2\dbch\af31505\loch\f2 omain
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -User <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the user used for the AdminAddress connection.
@@ -313,7 +313,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates an HTML fil\hich\af2\dbch\af31505\loch\f2 e with an .html extension.
@@ -323,7 +323,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
@@ -333,7 +333,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds a date timestamp to \hich\af2\dbch\af31505\loch\f2 the end of the file name.
@@ -349,7 +349,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fal\hich\af2\dbch\af31505\loch\f2 se
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  fal\hich\af2\dbch\af31505\loch\f2 se
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
@@ -364,7 +364,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output re\hich\af2\dbch\af31505\loch\f2 port.
@@ -375,7 +375,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard \hich\af2\dbch\af31505\loch\f2 characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard \hich\af2\dbch\af31505\loch\f2 characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
 \par 
@@ -383,7 +383,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
@@ -396,7 +396,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?\hich\af2\dbch\af31505\loch\f2        false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ReportFooter [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Outputs a footer section at the end of the report.
@@ -424,7 +424,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?      \hich\af2\dbch\af31505\loch\f2  false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -StartDate <DateTime>
 \par \hich\af2\dbch\af31505\loch\f2         Start date for the Audit Trail report.
@@ -441,7 +441,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value          \hich\af2\dbch\af31505\loch\f2       ((Get-Date -displayhint date).AddDays(-7))
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -EndDate <DateTime>
 \par \hich\af2\dbch\af31505\loch\f2         End date for the Audit Trail report.
@@ -458,7 +458,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                (Get-Date -displayhint date)
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hardware [<Swit\hich\af2\dbch\af31505\loch\f2 chParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on: Computer System, Disks, Processor and
@@ -470,7 +470,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -LimitTargetDevices <Int32>
 \par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Limits the number of target devices processed.
@@ -481,7 +481,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                1
 \par \hich\af2\dbch\af31505\loch\f2         Ac\hich\af2\dbch\af31505\loch\f2 cept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
@@ -491,7 +491,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
@@ -504,7 +504,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard\hich\af2\dbch\af31505\loch\f2  characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard\hich\af2\dbch\af31505\loch\f2  characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2 Page if}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
@@ -528,7 +528,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         Position?                   \hich\af2\dbch\af31505\loch\f2  named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2 Page if}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
@@ -540,50 +540,50 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    \hich\af2\dbch\af31505\loch\f2 false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2 Page if}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
-\hich\af2\dbch\af31505\loch\f2  the Cover Page has the F\hich\af2\dbch\af31505\loch\f2 ax field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the \hich\af2\dbch\af31505\loch\f2 Cover }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2 Page if}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2  the Cover Page has the Fax field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of\hich\af2\dbch\af31505\loch\f2  CF.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  on the computer running the script.
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Mi\hich\af2\dbch\af31505\loch\f2 crosoft\\Office\\Common\\UserInfo\\Company, whichever is populated
+\par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Default val\hich\af2\dbch\af31505\loch\f2 ue
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard \hich\af2\dbch\af31505\loch\f2 characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2 Page if}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
 \hich\af2\dbch\af31505\loch\f2  the Cover Page has the Phone field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone fiel\hich\af2\dbch\af31505\loch\f2 d:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word\hich\af2\dbch\af31505\loch\f2  2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
@@ -592,7 +592,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
 \par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
@@ -647,38 +647,38 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value     \hich\af2\dbch\af31505\loch\f2            Sideline
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
 \par \hich\af2\dbch\af31505\loch\f2         User name to use for the Cover Page and Footer.
-\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $env:username
+\par \hich\af2\dbch\af31505\loch\f2         Default va\hich\af2\dbch\af31505\loch\f2 lue is contained in $env:username
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    \hich\af2\dbch\af31505\loch\f2 named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Defa\hich\af2\dbch\af31505\loch\f2 ult value                $env:username
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Require\hich\af2\dbch\af31505\loch\f2 d?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                \hich\af2\dbch\af31505\loch\f2     false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
 \par \hich\af2\dbch\af31505\loch\f2         Default is 25.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Require\hich\af2\dbch\af31505\loch\f2 d?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                25
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
@@ -688,7 +688,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Acc\hich\af2\dbch\af31505\loch\f2 ept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -From <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
@@ -698,7 +698,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
@@ -708,7 +708,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
@@ -717,7 +717,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000003d}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 https:/go.microso
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000003d00}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 https:/go.microso
 \hich\af2\dbch\af31505\loch\f2 ft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
@@ -732,16 +732,18 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: PVS_Inventory_V6.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 6.0}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9249456 \hich\af2\dbch\af31505\loch\f2 6}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 6.0}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7950751 \hich\af2\dbch\af31505\loch\f2 7}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9249456 \hich\af2\dbch\af31505\loch\f2 April 25, 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9249456 \hich\af2\dbch\af31505\loch\f2 April }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7950751 \hich\af2\dbch\af31505\loch\f2 17}{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9249456 \hich\af2\dbch\af31505\loch\f2 , 202}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7950751 \hich\af2\dbch\af31505\loch\f2 3}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
+
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report by default.
-\par \hich\af2\dbch\af31505\loch\f2     The co\hich\af2\dbch\af31505\loch\f2 mputer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
@@ -750,8 +752,8 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -LimitTargetDevices 5
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report by default.
-\par \hich\af2\dbch\af31505\loch\f2     The Target Device section \hich\af2\dbch\af31505\loch\f2 is limited to the first five target devices in each Device
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML \hich\af2\dbch\af31505\loch\f2 report by default.
+\par \hich\af2\dbch\af31505\loch\f2     The Target Device section is limited to the first five target devices in each Device
 \par \hich\af2\dbch\af31505\loch\f2     Collection.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
@@ -760,12 +762,12 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -PDF
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -PDF
 \par 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Will use all Default values and save the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a PDF file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
-\par \hich\af2\dbch\af31505\loch\f2     AdminAddress = LocalHost
+\par \hich\af2\dbch\af31505\loch\f2     AdminAddress =\hich\af2\dbch\af31505\loch\f2  LocalHost
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -777,7 +779,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory\hich\af2\dbch\af31505\loch\f2 _V6.ps1 -Text
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -Text
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Saves the document as a formatted text file.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -785,11 +787,11 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ----------------------\hich\af2\dbch\af31505\loch\f2 ---- EXAMPLE 5 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -HTML
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Saves t\hich\af2\dbch\af31505\loch\f2 he document as an HTML file.
+\par \hich\af2\dbch\af31505\loch\f2     Saves the document as an HTML file.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -805,28 +807,28 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ----\hich\af2\dbch\af31505\loch\f2 ---------------------- EXAMPLE 7 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V6.ps1 -C\hich\af2\dbch\af31505\loch\f2 ompanyName "Carl Webster Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V6.ps1 -CompanyName "Carl Webster Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14427774\charrsid14427774 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage "Mod" -UserName "Carl Webster" -MSWord
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Carl Webster Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster fo\hich\af2\dbch\af31505\loch\f2 r the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V6.ps1 -CN "Carl Webster Consulting" -CP "Mod"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14427774\charrsid14427774 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V6.ps1 -CN "\hich\af2\dbch\af31505\loch\f2 Carl Webster Consulting" -CP "Mod"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
 \par \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster" -AdminAddress PVS1 -MSWord
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft W\hich\af2\dbch\af31505\loch\f2 ord report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
@@ -842,16 +844,16 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \f2\fs18\insrsid14427774\charrsid14427774 
 \par \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster" -AdminAddress PVS1 -User cwebster -Domain WebstersLab -MSWord
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates\hich\af2\dbch\af31505\loch\f2  a Microsoft Word report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Prompts for the password for the cwebster account.
+\par \hich\af2\dbch\af31505\loch\f2     Prompts for the password\hich\af2\dbch\af31505\loch\f2  for the cwebster account.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN\hich\af2\dbch\af31505\loch\f2 ).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
 \par \hich\af2\dbch\af31505\loch\f2         PVS1 for AdminAddress.
-\par \hich\af2\dbch\af31505\loch\f2         cwebster for User.
+\par \hich\af2\dbch\af31505\loch\f2         cwebster for \hich\af2\dbch\af31505\loch\f2 User.
 \par \hich\af2\dbch\af31505\loch\f2         WebstersLab for Domain.
 \par 
 \par 
@@ -897,15 +899,15 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ------\hich\af2\dbch\af31505\loch\f2 -------------------- EXAMPLE 12 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V6.ps1 -CompanyName "Sherlock Holmes Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid14427774\charrsid14427774 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet -UserName "Dr. Watson" -CompanyEmail SuperSleuth@SherlockHolmes.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a \hich\af2\dbch\af31505\loch\f2 Microsoft Word report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
-\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         She\hich\af2\dbch\af31505\loch\f2 rlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Company Email.
@@ -913,7 +915,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -----------------\hich\af2\dbch\af31505\loch\f2 --------- EXAMPLE 13 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -StartDate "01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9249456 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 " -EndDate "01/31/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9249456 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
@@ -934,7 +936,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS \hich\af2\dbch\af31505\loch\f2 C:\\PSScript >.\\PVS_Inventory_V6.ps1 -StartDate "01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9249456 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V\hich\af2\dbch\af31505\loch\f2 6.ps1 -StartDate "01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9249456 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2  10:00:00" -EndDate}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid14427774\charrsid14427774 
 \par \hich\af2\dbch\af31505\loch\f2     "01/31/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9249456 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 
@@ -945,10 +947,10 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML document.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     LocalHost for A\hich\af2\dbch\af31505\loch\f2 dminAddress.
-\par \hich\af2\dbch\af31505\loch\f2     Returns all Audit Trail entries from 01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9249456 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
-\hich\af2\dbch\af31505\loch\f2  10:00 AM through 01/31/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9249456 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
-\hich\af2\dbch\af31505\loch\f2  2:00
+\par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     Returns all A\hich\af2\dbch\af31505\loch\f2 udit Trail entries from 01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9249456 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2  10:00 AM through 01/31/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9249456 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2  2:00
 \par \hich\af2\dbch\af31505\loch\f2     PM.
 \par 
 \par 
@@ -956,7 +958,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 PVS_Inventory_V6.ps1 -Folder \\\\FileServer\\ShareName
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -Folder \\\\FileServer\\ShareName
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML document.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
@@ -968,7 +970,7 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -Dev -ScriptInfo -Log
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -Dev -Scrip\hich\af2\dbch\af31505\loch\f2 tInfo -Log
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates the default report.
 \par 
@@ -976,8 +978,8 @@ g>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\a
 \hich\af2\dbch\af31505\loch\f2 InventoryScriptErrors_yyyyMMddTHHmmssffff.txt that
 \par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors reported by the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Create\hich\af2\dbch\af31505\loch\f2 s a text file named }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2 PVS}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 InventoryScriptInfo_yyyy-MM-dd_HHmm.txt that
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2 PVS}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
+\hich\af2\dbch\af31505\loch\f2 InventoryScriptInfo_yyyy-MM-dd\hich\af2\dbch\af31505\loch\f2 _HHmm.txt that
 \par \hich\af2\dbch\af31505\loch\f2     contains all the script parameters and other basic information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file for transcript logging named
@@ -987,7 +989,7 @@ DocScriptTranscript_yyyyMMddTHHmmssffff.txt.
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ------\hich\af2\dbch\af31505\loch\f2 -------------------- EXAMPLE 17 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -SmtpServer mail.domain.tld -From}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid14427774\charrsid14427774 
@@ -1025,15 +1027,15 @@ DocScriptTranscript_yyyyMMddTHHmmssffff.txt.
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid6767713 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00032b005a65}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid14427774\charrsid6767713 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00032b005a6500}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid14427774\charrsid6767713 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "h\hich\af2\dbch\af31505\loch\f2 ttps://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6767713 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000806d}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid14427774\charrsid6767713 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000806d00}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid14427774\charrsid6767713 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gma\hich\af2\dbch\af31505\loch\f2 il or g-suite account, you may have to turn ON the "Less
+\par \hich\af2\dbch\af31505\loch\f2     To send an email\hich\af2\dbch\af31505\loch\f2  using a Gmail or g-suite account, you may have to turn ON the "Less
 \par \hich\af2\dbch\af31505\loch\f2     secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
 \par 
@@ -1043,28 +1045,27 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -----------\hich\af2\dbch\af31505\loch\f2 --------------- EXAMPLE 19 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  -------------------------- EXAMPLE 19 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -SmtpServer}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid14427774\charrsid14427774 
 \par \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protection.outlook.com -UseSSL -From
 \par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  ***OFFICE 365 Example***
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2 
- HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-offi\hich\af2\dbch\af31505\loch\f2 ce-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 
-{\*\datafield 
+ HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000006e}}}{\fldrslt {
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid14427774\charrsid6767713 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-\hich\af2\dbch\af31505\loch\f2 
-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000006e00}}}{\fldrslt {
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid14427774\charrsid6767713 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-dev\hich\af2\dbch\af31505\loch\f2 
+ice-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server labaddomain-com.mail.p\hich\af2\dbch\af31505\loch\f2 rotection.outlook.com, sending
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server labaddomain-com.mail.protection.outlook.com, sending
 \par \hich\af2\dbch\af31505\loch\f2     from SomeEmailAddress@labaddomain.com and sending to ITGroupDL@labaddomain.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and SSL.
@@ -1072,14 +1073,14 @@ us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-app
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2\hich\af2\dbch\af31505\loch\f2 0 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 20 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -SmtpServer smtp.office365.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14427774\charrsid14427774 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 \hich\af2\dbch\af31505\loch\f2 -SmtpServer smtp.office365.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.office365.com on port 58\hich\af2\dbch\af31505\loch\f2 7 using SSL, sending from
-\par \hich\af2\dbch\af31505\loch\f2     webster@carlwebster.com and sending to ITGroup@carlwebster.com.
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.office365.com on port 587 using SSL, sending from
+\par \hich\af2\dbch\af31505\loch\f2     webster@carlwebster.com and sending to ITGr\hich\af2\dbch\af31505\loch\f2 oup@carlwebster.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email, the script prompts
 \par \hich\af2\dbch\af31505\loch\f2     the user to enter valid credentials.
@@ -1087,15 +1088,15 @@ us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-app
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -----------------------\hich\af2\dbch\af31505\loch\f2 --- EXAMPLE 21 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 21 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V6.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14427774\charrsid14427774 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inve\hich\af2\dbch\af31505\loch\f2 ntory_V6.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14427774\charrsid14427774 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
-\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-\hich\af2\dbch\af31505\loch\f2 suite account, you may have to turn ON the "Less
-\par \hich\af2\dbch\af31505\loch\f2     secure app access" option on your account.
+\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to turn ON the "Less
+\par \hich\af2\dbch\af31505\loch\f2     secure app access" o\hich\af2\dbch\af31505\loch\f2 ption on your account.
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.gmail.com on port 587 using SSL, sending from
@@ -1103,7 +1104,7 @@ us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-app
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6767713 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid14427774\charrsid14427774 \hich\af2\dbch\af31505\loch\f2 email, the script prompts
-\par \hich\af2\dbch\af31505\loch\f2     the user to \hich\af2\dbch\af31505\loch\f2 enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     the user to enter valid credentials.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS
@@ -1226,8 +1227,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000010a2
-ccb39a58d801feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000c0e2
+04235271d901feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/PVS_V6_Script_ChangeLog.txt
+++ b/PVS_V6_Script_ChangeLog.txt
@@ -8,6 +8,34 @@
 #Version 6.00 is based on 5.21
 #
 
+#Version 6.07 17-Apr-2023
+#	Added new Farm properties introduced in 2303, SetupType and CloudSetupActive
+#		If(SetupType -eq 1 -and CloudSetupActive -eq $True )
+#		{
+#			"Farm is in cloud setup and all PVS servers have updated to cloud mode"
+#		}
+#		ElseIf(SetupType -eq 1 -and CloudSetupActive -eq $False )
+#		{
+#			"Farm is in cloud setup and all PVS servers have not updated to cloud mode"
+#		}
+#		ElseIf(SetupType -eq 0)
+#		{
+#			"Farm is in on-premises mode"
+#		}
+#	For Text output, fixed some formatting and alignment issues
+#	In Function OutputSite:
+#		If SetupType is 1 (Cloud), output the Cloud Customer ID and Name in the Licensing section
+#		Added two new Virtual Hosting Pool connection types added in 2303:
+#			4 = Azure
+#			5 = Google Cloud Platform
+#		Notes:
+#			You must run the PVS server and console in Azure to see Azure-specific options.
+#			You must run the PVS server and console in GCP to see GCP-specific options.
+#			You cannot stream to Azure or GCP from On-premises, for example.
+#			Citrix only supports creating PVS targets in Azure or GCP as part of streaming CVAD catalog VDAs. 
+#			Citrix only supports creating virtual hosting pool records for Azure and GCP from a CVAD 
+#				Hosting unit as part of the CVAD Setup Wizard.
+
 #Version 6.06 25-Apr-2022
 #	Change all Get-WMIObject to Get-CIMInstance
 #	General code cleanup


### PR DESCRIPTION
#Version 6.07 17-Apr-2023
#	Added new Farm properties introduced in 2303, SetupType and CloudSetupActive #		If(SetupType -eq 1 -and CloudSetupActive -eq $True ) #		{
#			"Farm is in cloud setup and all PVS servers have updated to cloud mode" #		}
#		ElseIf(SetupType -eq 1 -and CloudSetupActive -eq $False ) #		{
#			"Farm is in cloud setup and all PVS servers have not updated to cloud mode" #		}
#		ElseIf(SetupType -eq 0)
#		{
#			"Farm is in on-premises mode"
#		}
#	For Text output, fixed some formatting and alignment issues #	In Function OutputSite:
#		If SetupType is 1 (Cloud), output the Cloud Customer ID and Name in the Licensing section #		Added two new Virtual Hosting Pool connection types added in 2303: #			4 = Azure
#			5 = Google Cloud Platform
#		Notes:
#			You must run the PVS server and console in Azure to see Azure-specific options. #			You must run the PVS server and console in GCP to see GCP-specific options. #			You cannot stream to Azure or GCP from On-premises, for example. #			Citrix only supports creating PVS targets in Azure or GCP as part of streaming CVAD catalog VDAs.  #			Citrix only supports creating virtual hosting pool records for Azure and GCP from a CVAD  #				Hosting unit as part of the CVAD Setup Wizard.